### PR TITLE
Added LabelBelowBox and AlternativeLabelling settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+SynoAI.sln
+
 # User-specific files
 *.rsuser
 *.suo

--- a/SynoAI.sln
+++ b/SynoAI.sln
@@ -5,8 +5,8 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SynoAI", "SynoAI\SynoAI.csproj", "{D55517BF-4185-4B3D-956F-9CCE6425D88B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SynoAI.Tests", "SynoAI.Tests\SynoAI.Tests.csproj", "{C3A70D73-D1DD-46E4-882E-34CA833BE3EF}"
-EndProject
+#Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SynoAI.Tests", "SynoAI.Tests\SynoAI.Tests.csproj", "{C3A70D73-D1DD-46E4-882E-34CA833BE3EF}"
+#EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/SynoAI/AIs/DeepStack/DeepStackAI.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackAI.cs
@@ -39,7 +39,8 @@ namespace SynoAI.AIs.DeepStack
                     DeepStackResponse deepStackResponse = await GetResponse(response);
                     if (deepStackResponse.Success)
                     {
-                        IEnumerable<AIPrediction> predictions = deepStackResponse.Predictions.Where(x=> x.Confidence >= minConfidence).Select(x => new AIPrediction()
+
+                    IEnumerable<AIPrediction> predictions = deepStackResponse.Predictions.Where(x=> x.Confidence >= minConfidence).Select(x => new AIPrediction()  
                         {
                             Confidence = x.Confidence * 100,
                             Label = x.Label,

--- a/SynoAI/AIs/DeepStack/DeepStackAI.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackAI.cs
@@ -7,15 +7,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 namespace SynoAI.AIs.DeepStack
 {
     public class DeepStackAI : AI
     {
-        private const string URL_VISION_DETECTION = "v1/vision/detection";
-
         public async override Task<IEnumerable<AIPrediction>> Process(ILogger logger, Camera camera, byte[] image)
         {
             using (HttpClient client = new HttpClient())
@@ -36,7 +33,7 @@ namespace SynoAI.AIs.DeepStack
 
                 logger.LogDebug($"{camera.Name}: DeepStackAI: Sending image.");
 
-                HttpResponseMessage response = await client.PostAsync(URL_VISION_DETECTION, multipartContent);
+                HttpResponseMessage response = await client.PostAsync(Config.AIPath, multipartContent);
                 if (response.IsSuccessStatusCode)
                 {
                     DeepStackResponse deepStackResponse = await GetResponse(response);

--- a/SynoAI/Config.cs
+++ b/SynoAI/Config.cs
@@ -83,6 +83,14 @@ namespace SynoAI
         /// </summary>
         public static int TextOffsetY { get; private set; }
         /// <summary>
+        /// True will only place a reference number on each label image, later detailing object type and confidence percentage on the notification text
+        /// </summary>
+        public static bool AlternativeLabelling { get; private set; } 
+        /// <summary>
+        /// True will place each image label below the boundary box.
+        /// </summary>
+        public static bool LabelBelowBox { get; private set; } 
+        /// <summary>
         /// Whether this original snapshot generated from the API should be saved to the file system.
         /// </summary>
         public static bool SaveOriginalSnapshot { get; private set; }
@@ -146,6 +154,9 @@ namespace SynoAI
 
             MinSizeX = configuration.GetValue<int>("MinSizeX", 50);
             MinSizeY = configuration.GetValue<int>("MinSizeY", 50);
+
+            LabelBelowBox = configuration.GetValue<bool>("LabelBelowBox", false);
+            AlternativeLabelling = configuration.GetValue<bool>("AlternativeLabelling", false);
 
             SaveOriginalSnapshot = configuration.GetValue<bool>("SaveOriginalSnapshot", false);
 

--- a/SynoAI/Config.cs
+++ b/SynoAI/Config.cs
@@ -4,12 +4,8 @@ using SkiaSharp;
 using SynoAI.AIs;
 using SynoAI.Models;
 using SynoAI.Notifiers;
-using SynoAI.Notifiers.Pushbullet;
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI
 {
@@ -51,12 +47,6 @@ namespace SynoAI
         /// 2 = Low bandwidth
         /// </summary>
         public static CameraQuality Quality { get; private set; }
-
-        /// <summary>
-        /// The amount of time that needs to have passed between the last call to check the camera and the current call.
-        /// </summary>
-        public static int Delay { get; private set; }
-
         /// <summary>
         /// The hex code of the colour to use for the boxing around image matches.
         /// </summary>
@@ -91,6 +81,11 @@ namespace SynoAI
         /// </summary>
         public static bool LabelBelowBox { get; private set; } 
         /// <summary>
+        /// <summary>
+        /// Upon movement, the maximum number of snapshots sequentially retrieved from SSS until finding an object of interest (i.e. 4 snapshots)
+        /// </summary>
+        public static int MaxSnapshots { get; private set; } 
+        /// <summary>
         /// Whether this original snapshot generated from the API should be saved to the file system.
         /// </summary>
         public static bool SaveOriginalSnapshot { get; private set; }
@@ -100,6 +95,7 @@ namespace SynoAI
         /// </summary>
         public static AIType AI { get; private set; }
         public static string AIUrl { get; private set; }
+        public static string AIPath { get; private set; }
         public static int MinSizeX { get; private set; }
         public static int MinSizeY { get; private set; }
 
@@ -139,8 +135,7 @@ namespace SynoAI
             ApiVersionCamera = configuration.GetValue<int>("ApiVersionCamera", 9);  // Surveillance Station 8.0
 
             Quality = configuration.GetValue<CameraQuality>("Quality", CameraQuality.Balanced);
-
-            Delay = configuration.GetValue<int>("Delay", 5000);
+            
             DrawMode = configuration.GetValue<DrawMode>("DrawMode", DrawMode.Matches);
 
             BoxColor = configuration.GetValue<string>("BoxColor", SKColors.Red.ToString());
@@ -157,12 +152,18 @@ namespace SynoAI
 
             LabelBelowBox = configuration.GetValue<bool>("LabelBelowBox", false);
             AlternativeLabelling = configuration.GetValue<bool>("AlternativeLabelling", false);
+            MaxSnapshots = configuration.GetValue<int>("MaxSnapshots", 1);
+            if (MaxSnapshots > 254) {
+                MaxSnapshots = 254;
+                logger.LogWarning("ATTENTION: Config parameter MaxSnapshots is too big: Maximum accepted value is 254 ");
+            }
 
             SaveOriginalSnapshot = configuration.GetValue<bool>("SaveOriginalSnapshot", false);
 
             IConfigurationSection aiSection = configuration.GetSection("AI");
             AI = aiSection.GetValue<AIType>("Type", AIType.DeepStack);
             AIUrl = aiSection.GetValue<string>("Url");
+            AIPath = aiSection.GetValue<string>("Path","v1/vision/detection");
 
             Cameras = GenerateCameras(logger, configuration);
             Notifiers = GenerateNotifiers(logger, configuration);

--- a/SynoAI/Controllers/CameraController.cs
+++ b/SynoAI/Controllers/CameraController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
-using SynoAI.AIs;
 using SynoAI.Models;
 using SynoAI.Notifiers;
 using SynoAI.Services;
@@ -10,12 +8,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
+using SynoAI.Extensions;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace SynoAI.Controllers
@@ -105,26 +100,35 @@ namespace SynoAI.Controllers
                     
                     // Generate text for notifications
                     
-                    IEnumerable<String> notifications = new string[]{};
+                    IList<String> labels = new List<String>();
 
                     if (Config.AlternativeLabelling && Config.DrawMode == DrawMode.Matches)
                     {
-                        int counter = 1;
-                        foreach (AIPrediction prediction in validPredictions) 
+                        if (validPredictions.Count() == 1) 
                         {
-                            decimal confidence = Math.Round(prediction.Confidence, 0, MidpointRounding.AwayFromZero);
-                            String label = $"{counter}. {prediction.Label} ({confidence}%)";
-                            notifications.Append(label);
-                            counter++;
+                            decimal confidence = Math.Round(validPredictions.First().Confidence, 0, MidpointRounding.AwayFromZero);
+                            labels.Add($"{validPredictions.First().Label.FirstCharToUpper()} {confidence}%");
+                        }
+                        else 
+                        {
+                            //Since there is more than one object detected, include correlating number
+                            int counter = 1;
+                            foreach (AIPrediction prediction in validPredictions) 
+                            {
+                                decimal confidence = Math.Round(prediction.Confidence, 0, MidpointRounding.AwayFromZero);
+                                String label = $"{counter}. {prediction.Label.FirstCharToUpper()} {confidence}%";
+                                labels.Add(label);
+                                counter++;
+                            }
                         }
                     }
                     else
                     {
-                        notifications = validPredictions.Select(x => x.Label).ToList();
+                        labels = validPredictions.Select(x => x.Label.FirstCharToUpper()).ToList();
                     }
 
                     //Send Notifications                  
-                    await SendNotifications(camera, snapshotManager, notifications);
+                    await SendNotifications(camera, snapshotManager, labels);
                 }
                 else if (predictions.Count() > 0)
                 {
@@ -198,7 +202,7 @@ namespace SynoAI.Controllers
             return rotatedBitmap;
         }
 
-        private async Task SendNotifications(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> labels)
+        private async Task SendNotifications(Camera camera, ISnapshotManager snapshotManager, IList<String> labels)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
 

--- a/SynoAI/Controllers/CameraController.cs
+++ b/SynoAI/Controllers/CameraController.cs
@@ -73,12 +73,16 @@ namespace SynoAI.Controllers
                 // Take the snapshot from Surveillance Station
                 byte[] snapshot = await GetSnapshot(id);
                 _logger.LogInformation($"Snapshot {snapshotCount} of {Config.MaxSnapshots} received at EVENT TIME {overallStopwatch.ElapsedMilliseconds}ms.");
+
+                //See if the image needs to be rotated (or further processing in the future ?) previous to being analyzed by AI
                 snapshot = PreProcessSnapshot(camera, snapshot);
 
                 // Use the AI to get the valid predictions and then get all the valid predictions, which are all the AI predictions where the result from the AI is 
                 // in the list of types and where the size of the object is bigger than the defined value.
                 IEnumerable<AIPrediction> predictions = await GetAIPredications(camera, snapshot);
+
                 _logger.LogInformation($"Snapshot {snapshotCount} of {Config.MaxSnapshots} processed {predictions.Count()} objects at EVENT TIME {overallStopwatch.ElapsedMilliseconds}ms.");
+                
                 if (predictions != null)
                 {
                     IEnumerable<AIPrediction> validPredictions = predictions.Where(x =>
@@ -88,6 +92,11 @@ namespace SynoAI.Controllers
 
                     if (validPredictions.Count() > 0)
                     {
+
+                        // Because we don't want to process the image if it isn't even required, then we pass the snapshot manager to the notifiers. It will then perform 
+                        // the necessary actions when it's GetImage method is called.
+                        SnapshotManager snapshotManager = new SnapshotManager(snapshot, predictions, validPredictions, _snapshotManagerLogger);
+
                         // Save the original unprocessed image if required
                         if (Config.SaveOriginalSnapshot)
                         {
@@ -95,10 +104,6 @@ namespace SynoAI.Controllers
                             SnapshotManager.SaveOriginalImage(_logger, camera, snapshot);
                         }
 
-                        // Because we don't want to process the image if it isn't even required, then we pass the snapshot manager to the notifiers. It will then perform 
-                        // the necessary actions when it's GetImage method is called.
-                        SnapshotManager snapshotManager = new SnapshotManager(snapshot, predictions, validPredictions, _snapshotManagerLogger);
-                        
                         // Generate text for notifications                  
                         IList<String> labels = new List<String>();
 
@@ -157,23 +162,27 @@ namespace SynoAI.Controllers
         /// <returns>A byte array of the image.</returns>
         private byte[] PreProcessSnapshot(Camera camera, byte[] snapshot)
         {
-            if (camera.Rotate == 0)
+            if (camera.Rotate != 0)
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
+                // Load the bitmap & rotate the image
+                //SKBitmap bitmap = SKBitmap.Decode(new MemoryStream(snapshot));
+                SKBitmap bitmap = SKBitmap.Decode(snapshot);
+
+                _logger.LogInformation($"{camera.Name}: Rotating image {camera.Rotate} degrees.");
+                bitmap = Rotate(bitmap, camera.Rotate);
+
+                using (SKPixmap pixmap = bitmap.PeekPixels())
+                using (SKData data = pixmap.Encode(SKEncodedImageFormat.Jpeg, 100)) 
+                { 
+                    _logger.LogInformation($"{camera.Name}: Image preprocessing complete ({stopwatch.ElapsedMilliseconds}ms).");
+                    return data.ToArray();
+                }
+            }
+            else 
             {
                 return snapshot;
-            }
-
-            Stopwatch stopwatch = Stopwatch.StartNew();
-
-            // Load the bitmap & rotate the image
-            SKBitmap bitmap = SKBitmap.Decode(new MemoryStream(snapshot));
-            _logger.LogInformation($"{camera.Name}: Rotating image {camera.Rotate} degrees.");
-            bitmap = Rotate(bitmap, camera.Rotate);
-
-            using (SKPixmap pixmap = bitmap.PeekPixels())
-            using (SKData data = pixmap.Encode(SKEncodedImageFormat.Jpeg, 100)) 
-            { 
-                _logger.LogInformation($"{camera.Name}: Image preprocessing complete ({stopwatch.ElapsedMilliseconds}ms).");
-                return data.ToArray();
             }
         }
 
@@ -260,7 +269,6 @@ namespace SynoAI.Controllers
             if (predictions == null)
             {
                 _logger.LogError($"{camera}: Failed to get get predictions.");
-                return null;
             }
             else if (_logger.IsEnabled(LogLevel.Information))
             {

--- a/SynoAI/Notifiers/Email/Email.cs
+++ b/SynoAI/Notifiers/Email/Email.cs
@@ -53,7 +53,7 @@ namespace SynoAI.Notifiers.Email
         /// <param name="snapshotManager">A thread safe object for fetching the processed image.</param>
         /// <param name="foundTypes">The list of types that were found.</param>
         /// <param name="logger">A logger.</param>
-        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> foundTypes, ILogger logger)
+        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IList<string> foundTypes, ILogger logger)
         {
             using (logger.BeginScope($"Email '{Destination}'"))
             {

--- a/SynoAI/Notifiers/INotifier.cs
+++ b/SynoAI/Notifiers/INotifier.cs
@@ -15,6 +15,6 @@ namespace SynoAI.Notifiers
         /// <summary>
         /// Handles the send of the notification.
         /// </summary>
-        Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> foundTypes, ILogger logger);
+        Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IList<string> foundTypes, ILogger logger);
     }
 }

--- a/SynoAI/Notifiers/NotifierBase.cs
+++ b/SynoAI/Notifiers/NotifierBase.cs
@@ -3,34 +3,45 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using SynoAI.Extensions;
 using SynoAI.Models;
 using SynoAI.Services;
+using SynoAI.Extensions;
 
 namespace SynoAI.Notifiers
 {
     public abstract class NotifierBase : INotifier
     {
         public IEnumerable<string> Cameras { get; set;} 
-        public abstract Task SendAsync(Camera camera, ISnapshotManager fileAccessor, IEnumerable<string> foundTypes, ILogger logger);
+        public abstract Task SendAsync(Camera camera, ISnapshotManager fileAccessor, IList<string> foundTypes, ILogger logger);
 
-        protected string GetMessage(Camera camera, IEnumerable<string> foundTypes)
+        protected string GetMessage(Camera camera, IList<string> foundTypes)
         {
             if (Config.AlternativeLabelling && Config.DrawMode == DrawMode.Matches)
             {
+                //defaulting into generic label type
                 String typeLabel = "object";
 
                 if (camera.Types.Count() == 1) {
+                    //Only one object type configured: use it instead of generic "object" label
                     typeLabel = camera.Types.First();
                 }
 
                 if (foundTypes.Count() > 1)
                 {
-                    return $"Detected {foundTypes.Count()} {typeLabel}s on {camera.Name}:\n{String.Join("\n", foundTypes.Select(x => x).ToArray())}";
-                }
-                return $"Detected on {camera.Name}:{foundTypes.First().Substring(foundTypes.First().IndexOf(" "))}";              
-            } 
-            return $"Motion detected on {camera.Name}\n\nDetected {foundTypes.Count()} objects:\n{String.Join("\n", foundTypes.Select(x => x.FirstCharToUpper()).ToArray())}";         
+                    //Several objects detected
+                    return $"{camera.Name}: {foundTypes.Count()} {typeLabel}s\n{String.Join("\n", foundTypes.Select(x => x).ToArray())}";
+                } 
+                else 
+                {
+                    //Just one object detected
+                    return $"{camera.Name}: {foundTypes.First()}";    
+                }      
+            }
+            else 
+            {
+                //Standard (old) labelling
+                return $"Motion detected on {camera.Name}\n\nDetected {foundTypes.Count()} objects:\n{String.Join("\n", foundTypes.Select(x => x).ToArray())}";   
+            }
         }
     }
 }

--- a/SynoAI/Notifiers/NotifierBase.cs
+++ b/SynoAI/Notifiers/NotifierBase.cs
@@ -16,7 +16,21 @@ namespace SynoAI.Notifiers
 
         protected string GetMessage(Camera camera, IEnumerable<string> foundTypes)
         {
-            return $"Motion detected on {camera.Name}\n\nDetected {foundTypes.Count()} objects:\n{String.Join("\n", foundTypes.Select(x => x.FirstCharToUpper()).ToArray())}";
+            if (Config.AlternativeLabelling && Config.DrawMode == DrawMode.Matches)
+            {
+                String typeLabel = "object";
+
+                if (camera.Types.Count() == 1) {
+                    typeLabel = camera.Types.First();
+                }
+
+                if (foundTypes.Count() > 1)
+                {
+                    return $"Detected {foundTypes.Count()} {typeLabel}s on {camera.Name}:\n{String.Join("\n", foundTypes.Select(x => x).ToArray())}";
+                }
+                return $"Detected on {camera.Name}:{foundTypes.First().Substring(foundTypes.First().IndexOf(" "))}";              
+            } 
+            return $"Motion detected on {camera.Name}\n\nDetected {foundTypes.Count()} objects:\n{String.Join("\n", foundTypes.Select(x => x.FirstCharToUpper()).ToArray())}";         
         }
     }
 }

--- a/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
+++ b/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
@@ -34,7 +34,7 @@ namespace SynoAI.Notifiers.Pushbullet
         /// <param name="snapshotManager">A thread safe object for fetching the processed image.</param>
         /// <param name="foundTypes">The list of types that were found.</param>
         /// <param name="logger">A logger.</param>
-        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> foundTypes, ILogger logger)
+        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IList<string> foundTypes, ILogger logger)
         {
             // Pushbullet file uploads are a two part process. First we need to request to upload a file
             using (HttpClient client = new HttpClient())

--- a/SynoAI/Notifiers/Telegram/Telegram.cs
+++ b/SynoAI/Notifiers/Telegram/Telegram.cs
@@ -42,7 +42,7 @@ namespace SynoAI.Notifiers.Telegram
         /// <param name="snapshotManager">A thread safe object for fetching the processed image.</param>
         /// <param name="foundTypes">The list of types that were found.</param>
         /// <param name="logger">A logger.</param>
-        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> foundTypes, ILogger logger)
+        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IList<string> foundTypes, ILogger logger)
         {
             using (logger.BeginScope($"Telegram '{ChatID}'"))
             {

--- a/SynoAI/Notifiers/Webhook/Webhook.cs
+++ b/SynoAI/Notifiers/Webhook/Webhook.cs
@@ -65,7 +65,7 @@ namespace SynoAI.Notifiers.Webhook
         /// <param name="snapshotManager">A thread safe object for fetching a readonly file stream.</param>
         /// <param name="foundTypes">The list of types that were found.</param>
         /// <param name="logger">A logger.</param>
-        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IEnumerable<string> foundTypes, ILogger logger)
+        public override async Task SendAsync(Camera camera, ISnapshotManager snapshotManager, IList<string> foundTypes, ILogger logger)
         {
             logger.LogInformation($"{camera.Name}: Webhook: Processing");
             using (HttpClient client = new HttpClient())

--- a/SynoAI/Services/SnapshotManager.cs
+++ b/SynoAI/Services/SnapshotManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using SynoAI.Models;
+using SynoAI.Extensions;
 
 namespace SynoAI.Services
 {
@@ -110,18 +111,22 @@ namespace SynoAI.Services
                             Color = GetColour(Config.BoxColor)
                         });
                         
-                        //Label creation, either classic label or alternative labelling
+                        //Label creation, either classic label or alternative labelling (and only if there is more than one object)
                         string label = String.Empty;
 
                         if (Config.AlternativeLabelling && Config.DrawMode == DrawMode.Matches) 
                         {
-                            label = counter.ToString();
-                            counter++;
+                            //On alternatie labelling, just place a reference number and only if there is more than one object
+                            if (_validPredictions.Count() > 1) 
+                            {
+                                label = counter.ToString();
+                                counter++;
+                            }
                         }
                         else
                         {
                             decimal confidence = Math.Round(prediction.Confidence, 0, MidpointRounding.AwayFromZero);
-                            label = $"{prediction.Label} ({confidence}%)";
+                            label = $"{prediction.Label.FirstCharToUpper()} {confidence}%";
                         }
 
                         //Label positioning

--- a/SynoAI/Services/SnapshotManager.cs
+++ b/SynoAI/Services/SnapshotManager.cs
@@ -82,7 +82,7 @@ namespace SynoAI.Services
             _logger.LogInformation($"{camera.Name}: Processing image boundaries.");
 
             // Load the bitmap 
-            SKBitmap image = SKBitmap.Decode(new MemoryStream(_snapshot));
+            SKBitmap image = SKBitmap.Decode(_snapshot);
 
             // Don't process the drawing if the drawing mode is off
             if (Config.DrawMode == DrawMode.Off)

--- a/SynoAI/appsettings.json
+++ b/SynoAI/appsettings.json
@@ -14,7 +14,6 @@
   "Password": "",
   "AllowInsecureUrl": false,
 
-  "Delay": 5000,
   "DrawMode": "Matches",
 
   "AI": {


### PR DESCRIPTION
Hi There @djdd87 !

Maybe you find it interesting to incorporate this small contribution into your code  (as a whole, part or it is just useful as an idea for yet another enhancement). 

LabelBelowBox setting: when True, it will place each text label below the object's box inside the image. Default: False.

This is because in my case, my cameras usually detects persons which tend to be walking on top of the image, so labels where being cut-off out of frame.

AlternativeLabelling setting: When True, and also DrawMode is set to "Match" then  the label will show just a reference number, which the will be correlated while text listing each object on Telegram or Pushbullet notification services. Default: False.

This is because in my case, when more than one person is detected walking in groups, sometimes labels ended on top of each other, illegible.

Also I minimized the text send on each notification, and added a bit more of logic so it doesn't say "object" if I am just searching for "person" in that camera. This helped me to unclutter the telegram screen, while also fitting almost three complete notifications on my telephone screen:

![ede0fec0-d27f-4fa2-8591-ea8a77917aa4](https://user-images.githubusercontent.com/31453004/126224533-30668456-fd80-4dc6-b754-da4a81429659.jpg)

![8607f99f-4f64-4cc4-8ff5-242863e56ac3](https://user-images.githubusercontent.com/31453004/126224732-ac50b4a9-1c50-4505-bb4e-08f3d60d3b4d.jpg)

Sorry for such big images. Had no time to scale them down, but wanted to show you the "alternative labelling". If that setting is "false" then everything is shown as before (like your current version).

cheers! Enrique.




