### PR TITLE
Added MaxSizeX & MaxSizeY for valid object detection

### DIFF
--- a/SynoAI/Config.cs
+++ b/SynoAI/Config.cs
@@ -112,6 +112,15 @@ namespace SynoAI
         public static int MinSizeY { get; private set; }
 
         /// <summary>
+        /// The default maximum width that an object must be to be considered valid for reporting. Can be overridden on a camera by camera basis to account for different camera resolutions.
+        /// </summary>
+        public static int MaxSizeX { get; private set; }
+        /// <summary>
+        /// The default maximum height that an object must be to be considered valid for reporting. Can be overridden on a camera by camera basis to account for different camera resolutions.
+        /// </summary>
+        public static int MaxSizeY { get; private set; }
+
+        /// <summary>
         /// The list of cameras.
         /// </summary>
         public static IEnumerable<Camera> Cameras { get; private set; }
@@ -161,6 +170,10 @@ namespace SynoAI
 
             MinSizeX = configuration.GetValue<int>("MinSizeX", 50);
             MinSizeY = configuration.GetValue<int>("MinSizeY", 50);
+
+            // euquiq: A bit overkill to use int.MaxValue :)
+            MaxSizeX = configuration.GetValue<int>("MaxSizeX", int.MaxValue);
+            MaxSizeY = configuration.GetValue<int>("MaxSizeY", int.MaxValue);
 
             LabelBelowBox = configuration.GetValue<bool>("LabelBelowBox", false);
             AlternativeLabelling = configuration.GetValue<bool>("AlternativeLabelling", false);

--- a/SynoAI/Controllers/CameraController.cs
+++ b/SynoAI/Controllers/CameraController.cs
@@ -84,7 +84,8 @@ namespace SynoAI.Controllers
                     if (rawPredictions.Count() > 0)
                     {
                         IEnumerable<AIPrediction> predictions = rawPredictions.Where(x =>
-                            x.SizeX >= camera.GetMinSizeX() && x.SizeY >= camera.GetMinSizeY())     // Is bigger than the minimum size
+                            x.SizeX >= camera.GetMinSizeX() && x.SizeY >= camera.GetMinSizeY() &&   // Is bigger than the minimum size
+                            x.SizeX <= camera.GetMaxSizeX() && x.SizeY <= camera.GetMaxSizeY())     // Is smaller than the maximum size 
                             .ToList();
 
                          IEnumerable<AIPrediction> validPredictions = predictions.Where(x =>

--- a/SynoAI/Models/Camera.cs
+++ b/SynoAI/Models/Camera.cs
@@ -29,6 +29,14 @@ namespace SynoAI.Models
         /// </summary>
         public int? MinSizeY { get; set; }
         /// <summary>
+        /// The maximum size the object must be horizontally to be considered as a valid result.
+        /// </summary>
+        public int? MaxSizeX { get; set; }
+        /// <summary>
+        /// The maximum size the object must be vertically to be considered as a valid result.
+        /// </summary>
+        public int? MaxSizeY { get; set; }
+        /// <summary>
         /// The number of degrees to rotate the captured image before processing.
         /// </summary>
         public float Rotate { get; set; }
@@ -54,6 +62,21 @@ namespace SynoAI.Models
             return MinSizeY ?? Config.MinSizeY;
         }
 
+        /// <summary>
+        /// Gets the maximum size the object must be horizontally to be considered as a valid result from either the current camera, or the main config default if not specified.
+        /// </summary>
+        public int GetMaxSizeX()
+        {
+            return MaxSizeX ?? Config.MaxSizeX;
+        }
+
+        /// <summary>
+        /// Gets the maximum size the object must be vertically to be considered as a valid result from either the current camera, or the main config default if not specified.
+        /// </summary>
+        public int GetMaxSizeY()
+        {
+            return MaxSizeY ?? Config.MaxSizeY;
+        }
 
         /// <summary>
         /// Gets the maximum number of snapshots to take for the current camera, or the main config default if not specified.


### PR DESCRIPTION
As the title says. This was motivated by a large tree in front of my house which sometimes confuses DeepStack AI and gets labelled as "person".

![Captura de Pantalla 2021-09-11 a la(s) 13 11 12](https://user-images.githubusercontent.com/31453004/132954233-0f3ccde9-2f48-4d6a-923f-56120bb0b3e4.png)

I can safely filter it out thanks to these new config parameters. 