### PR TITLE
Add Pushover priority notification required values "retry" and "expire"

### DIFF
--- a/SynoAI/Notifiers/Pushover/PushoverFactory.cs
+++ b/SynoAI/Notifiers/Pushover/PushoverFactory.cs
@@ -14,9 +14,9 @@ namespace SynoAI.Notifiers.Pushover
             string userKey = section.GetValue<string>("UserKey");
             List<string> devices = section.GetValue<List<string>>("Devices");
             string sound = section.GetValue<string>("Sound");   // https://pushover.net/api#sounds
-            PushoverPriority priority = section.GetValue<PushoverPriority>("Priority", PushoverPriority.Normal); 
-            int retry = section.GetValue<int>("retry");
-            int expire = section.GetValue<int>("expire");
+            PushoverPriority priority = section.GetValue("Priority", PushoverPriority.Normal); 
+            int retry = section.GetValue<int>("Retry");
+            int expire = section.GetValue<int>("Expire");
 
             return new Pushover()
             {

--- a/SynoAI/Notifiers/Pushover/PushoverFactory.cs
+++ b/SynoAI/Notifiers/Pushover/PushoverFactory.cs
@@ -15,6 +15,8 @@ namespace SynoAI.Notifiers.Pushover
             List<string> devices = section.GetValue<List<string>>("Devices");
             string sound = section.GetValue<string>("Sound");   // https://pushover.net/api#sounds
             PushoverPriority priority = section.GetValue<PushoverPriority>("Priority", PushoverPriority.Normal); 
+            int retry = section.GetValue<int>("retry");
+            int expire = section.GetValue<int>("expire");
 
             return new Pushover()
             {
@@ -23,6 +25,8 @@ namespace SynoAI.Notifiers.Pushover
                 Devices = devices, 
                 Sound = sound,
                 Priority = priority,
+                Retry = retry,
+                Expire = expire
             };
         }
     }


### PR DESCRIPTION
Explained in [Pushover API documentation](https://pushover.net/api#priority2) :
Pushover priority notification with value "2" requires additional "retry" and "expire" parameter