### PR TITLE
Add MQTT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For example, if you are using the docker image/version v1.1.0, then ensure you h
   * [HomeAssistant](#homeassistant)
   * [Pushover](#pushover)
   * [Discord](#discord)
+  * [MQTT](#mqtt)
 * [Caveats](#caveats)
 * [Configuration](#configuration)
   * [1) Configure Deepstack](#1-configure-deepstack)
@@ -358,6 +359,53 @@ Send notifications to a Discord server via Discord Webhooks. You can get a Disco
 ```
 * Url [required]: The URL of the Discord Webhook you want to send messages to. 
 
+### MQTT 
+Send notifications as MQTT messages. Messages are JSON-encoded and sent to the `{BaseTopic}\{CameraName}\notification` topic. You can optionally include the capture as a base64 encoded JPG, but this is disabled by default.
+
+#### Configuration
+```json
+{
+  "Type": "MQTT",
+  "Host": "mqtt.domain.com",
+  "Port": 1883,
+  "Username": "user",
+  "Password": "password",
+  "BaseTopic": "synoai",
+  "SendImage": "false"
+}
+```
+* Host [required]: The hostname or IP for the MQTT broker
+* Port [optional] (Default: `1883`): The port the MQTT broker is listening to
+* Username [optional]: The username to use
+* Password [optional]: The password to use
+* BaseTopic [optional] (Default: `"synoai"`): The base topic for messages
+* SendImage [optional] (Default: ```false```): Whether to send a base64-encoded JPG in the `image` field.
+
+#### Example payload data
+The following is example data for when ```SendImage``` is ```false```.
+
+```json
+{
+  "camera": "Driveway",
+  "foundTypes": [
+    "Car"
+  ],
+  "predictions": [
+    {
+      "Label": "car",
+      "Confidence": 67.89117,
+      "MinX": 1738,
+      "MinY": 420,
+      "MaxX": 2304,
+      "MaxY": 844,
+      "SizeX": 566,
+      "SizeY": 424
+    }
+  ],
+  "message": "Motion detected on Driveway\n\nDetected 1 objects:\nCar",
+  "image": null
+}
+```
 
 ## Caveats
 * SynoAI still relies on Surveillance Station triggering the motion alerts

--- a/SynoAI/Notifiers/INotifier.cs
+++ b/SynoAI/Notifiers/INotifier.cs
@@ -17,8 +17,16 @@ namespace SynoAI.Notifiers
         /// </summary>
         IEnumerable<string> Types { get; set; }
         /// <summary>
+        /// Handles any initialization for the notifier (e.g. establishing a long-lived connection).
+        /// </summary>
+        Task InitializeAsync(ILogger logger);
+        /// <summary>
         /// Handles the send of the notification.
         /// </summary>
         Task SendAsync(Camera camera, Notification notification, ILogger logger);
+        /// <summary>
+        /// Handles any clean up for the notifier (e.g. closing a long-lived connection).
+        /// </summary>
+        Task CleanupAsync(ILogger logger);
     }
 }

--- a/SynoAI/Notifiers/Mqtt/Mqtt.cs
+++ b/SynoAI/Notifiers/Mqtt/Mqtt.cs
@@ -1,0 +1,168 @@
+﻿using Microsoft.Extensions.Logging;
+using SynoAI.Models;
+using System.Threading.Tasks;
+using MQTTnet.Client;
+using MQTTnet;
+using System.Threading;
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace SynoAI.Notifiers.Mqtt
+{
+    /// <summary>
+    /// Sends a message over MQTT.
+    /// </summary>
+    public sealed class Mqtt : NotifierBase
+    {
+        /// <summary>
+        /// The username when using Basic authentication.
+        /// </summary>
+        public string Host { get; set; }
+        /// <summary>
+        /// The username when using Basic authentication.
+        /// </summary>
+        public int? Port { get; set; }
+        /// <summary>
+        /// The username when using Basic authentication.
+        /// </summary>
+        public string Username { get; set; }
+        /// <summary>
+        /// The password to use when using Basic authentication.
+        /// </summary>
+        public string Password { get; set; }
+        /// <summary>
+        /// Notifications will be sent to "{BaseTopic}/{CameraName}/notification".
+        /// </summary>
+        public string BaseTopic { get; set; }
+        /// <summary>
+        /// Whether the image should be sent as part of the message payload.
+        /// </summary>
+        public bool SendImage { get; set; }
+
+        private const double _connectionTimeoutSeconds = 10.0;
+        private IMqttClient _client;
+
+        public Mqtt() : base()
+        {
+            _client = (new MQTTnet.MqttFactory()).CreateMqttClient();
+        }
+
+        public override Task InitializeAsync(ILogger logger)
+        {
+            return ConnectAsync(logger);
+        }
+
+        public override async Task SendAsync(Camera camera, Notification notification, ILogger logger)
+        {
+            logger.LogInformation("MQTT: sending notification.");
+
+            if (BaseTopic == null)
+            {
+                logger.LogError("MQTT: send aborted because base topic is not configured");
+                return;
+            }
+
+            MqttApplicationMessageBuilder messageBuilder = new MqttApplicationMessageBuilder()
+                .WithTopic($"{BaseTopic}/{camera.Name}/notification")
+                .WithPayload(GeneratePayload(camera, notification));
+            
+            await _client.PublishAsync(messageBuilder.Build());
+        }
+
+        /// <summary>
+        /// Connects to the MQTT broker
+        /// </summary>
+        private async Task ConnectAsync(ILogger logger)
+        {
+            if (_client.IsConnected)
+            {
+                logger.LogError("MQTT: connection aborted because client is already connected.");
+                return;
+            }
+
+            if (Host == null)
+            {
+                logger.LogError("MQTT: connection failed because no host specified.");
+                return;
+            }
+
+            logger.LogInformation("MQTT: connecting to broker.");
+
+            var mqttClientOptionsBuilder = new MqttClientOptionsBuilder()
+                .WithTcpServer(Host, Port);
+            
+            if (Username != null)
+            {
+                mqttClientOptionsBuilder.WithCredentials(Username, Password ?? "");
+            }
+
+            try
+            {
+                using (var timeoutToken = new CancellationTokenSource(TimeSpan.FromSeconds(_connectionTimeoutSeconds)))
+                {
+                    await _client.ConnectAsync(mqttClientOptionsBuilder.Build(), timeoutToken.Token);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("MQTT: connection failed.");
+                logger.LogError(ex, "An exception occurred");
+            }
+        }
+
+        /// <summary>
+        /// Disconnects from the MQTT broker
+        /// </summary>
+        private async Task DisconnectAsync(ILogger logger)
+        {
+            try
+            {
+                if (_client != null && _client.IsConnected)
+                {
+                    logger.LogInformation("MQTT: disconnecting from broker.");
+                    await _client.DisconnectAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("MQTT: disconnect failed.");
+                logger.LogError(ex, "An exception occurred");
+            }
+        }
+
+        /// <summary>
+        /// Generates the message payload as a JSON string encoded as UTF-8
+        /// </summary>
+        private byte[] GeneratePayload(Camera camera, Notification notification)
+        {
+            var request = new
+            {
+                camera = camera.Name,
+                foundTypes = notification.FoundTypes,
+                predictions = notification.ValidPredictions,
+                message = GetMessage(camera, notification.FoundTypes),
+                image = SendImage ? ToBase64String(notification.ProcessedImage.GetReadonlyStream()) : null
+            };
+
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request));
+        }
+
+        /// <summary>
+        /// Returns FileStream data as a base64-encoded string
+        /// </summary>
+        private string ToBase64String(FileStream fileStream)
+        {
+            byte[] buffer = new byte[fileStream.Length];
+            fileStream.Read(buffer, 0, (int)fileStream.Length);
+                
+            return Convert.ToBase64String(buffer);
+        }
+
+        public override Task CleanupAsync(ILogger logger)
+        {
+            return DisconnectAsync(logger);
+        }
+    }
+}

--- a/SynoAI/Notifiers/Mqtt/MqttFactory.cs
+++ b/SynoAI/Notifiers/Mqtt/MqttFactory.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using SynoAI.Notifiers.Webhook;
+
+namespace SynoAI.Notifiers.Mqtt
+{
+    public class MqttFactory : NotifierFactory
+    {
+        public override INotifier Create(ILogger logger, IConfigurationSection section)
+        {
+            using (logger.BeginScope(nameof(MqttFactory)))
+            {
+                logger.LogInformation("Processing MQTT config");
+
+                string host = section.GetValue<string>("Host", null);
+                int? port = section.GetValue<int?>("Port", null);
+                string username = section.GetValue<string>("Username", null);
+                string password = section.GetValue<string>("Password", null);
+                string baseTopic = section.GetValue<string>("BaseTopic", "synoai");
+                bool sendImage = section.GetValue<bool>("SendImage", false);
+
+                Mqtt mqtt = new Mqtt()
+                {
+                    Host = host,
+                    Port = port,
+                    Username = username,
+                    Password = password,
+                    BaseTopic = baseTopic,
+                    SendImage = sendImage
+                };
+
+                return mqtt;
+            }
+        }
+    }
+}

--- a/SynoAI/Notifiers/NotifierBase.cs
+++ b/SynoAI/Notifiers/NotifierBase.cs
@@ -15,7 +15,12 @@ namespace SynoAI.Notifiers
         public IEnumerable<string> Cameras { get; set; } 
         public IEnumerable<string> Types { get; set; } 
         
+
+        public virtual Task InitializeAsync(ILogger logger) { return Task.CompletedTask; }
+
         public abstract Task SendAsync(Camera camera, Notification notification, ILogger logger);
+
+        public virtual Task CleanupAsync(ILogger logger) { return Task.CompletedTask; }
 
         protected string GetMessage(Camera camera, IEnumerable<string> foundTypes, string errorMessage = null)
         {

--- a/SynoAI/Notifiers/NotifierFactory.cs
+++ b/SynoAI/Notifiers/NotifierFactory.cs
@@ -7,6 +7,7 @@ using SynoAI.Notifiers.SynologyChat;
 using SynoAI.Notifiers.Telegram;
 using SynoAI.Notifiers.Webhook;
 using SynoAI.Notifiers.Discord;
+using SynoAI.Notifiers.Mqtt;
 using System;
 using System.Collections.Generic;
 
@@ -44,6 +45,9 @@ namespace SynoAI.Notifiers
                     break;
                 case NotifierType.Discord:
                     factory = new DiscordFactory();
+                    break;
+                case NotifierType.MQTT:
+                    factory = new MqttFactory();
                     break;
                 default:
                     throw new NotImplementedException(type.ToString());

--- a/SynoAI/Notifiers/NotifierType.cs
+++ b/SynoAI/Notifiers/NotifierType.cs
@@ -34,5 +34,9 @@ namespace SynoAI.Notifiers
         /// Calls a webhook with the image attached.
         /// </summary>
         Webhook,
+        /// <summary>
+        /// Sends an MQTT message optionally with the image attached.
+        /// </summary>
+        MQTT,
     }
 }

--- a/SynoAI/SynoAI.csproj
+++ b/SynoAI/SynoAI.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="2.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="MQTTnet" Version="4.1.0.247" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.155" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.155" />


### PR DESCRIPTION
Closes #110 

This PR's primary purpose is to add MQTT support. MQTT generally utilizes longer-lived connections than those of the other HTTP-based notifiers, so I considered 3 potential solutions:

1. Open and close the connection to the MQTT broker on every notification
2. Open the connection on the first notification and persist it for the life of the app
3. Open the connection as part of initialization and persist it for the life of the app

1 seemed a bit wasteful, especially when notifying rapidly or across cameras simultaneously. I didn't like 2 because you wouldn't know about potential errors in the MQTT connection until an event, which seemed less than ideal. So I went with 3. I decided to have the `Mqtt` notifier own the MQTT client as this seems consistent with the HTTP-based notifiers. So to support opening and closing long-lived connections, I added `InitializeAsync` and `CleanupAsync` methods to `INotifier` and created no-op implementations in `NotifierBase`. We could instead use the `IDisposableAsync` pattern for clean up, but this would require that notifiers take ownership of the `ILogger` in a new constructor on `INotifier`.

MQTT messages are JSON blobs that inherit their structure from the messages in `Webhook`. You can include a base64 encoded image in the message, but this is disabled by default. Images can be several MB and while MQTT supports this, it is not uncommon for brokers to be configured with smaller max sizes on messages. A better solution may be to serve the image via a URL sent in the message, but that is beyond the scope of this PR.

Let me know if you want to go with one of the other designs on the initialization/cleanup--should be a simple change. Also, I'm an ASP.NET noob, so please check the changes to `Startup.cs`. Thanks!