### PR TITLE
Update to dotnet 7 and enabling code analysis

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/SynoAI.Tests/SynoAI.Tests.csproj
+++ b/SynoAI.Tests/SynoAI.Tests.csproj
@@ -1,16 +1,40 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+		<AnalysisLevel>latest-recommended</AnalysisLevel>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SynoAI\SynoAI.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/SynoAI.Tests/SynoAI.Tests.csproj
+++ b/SynoAI.Tests/SynoAI.Tests.csproj
@@ -7,7 +7,7 @@
 		<IsPackable>false</IsPackable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-		<AnalysisLevel>latest-recommended</AnalysisLevel>
+		<AnalysisLevel>6.0-recommended</AnalysisLevel>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SynoAI.Tests/UnitTest1.cs
+++ b/SynoAI.Tests/UnitTest1.cs
@@ -1,18 +1,6 @@
-using NUnit.Framework;
-
 namespace SynoAI.Tests
 {
     public class Tests
     {
-        [SetUp]
-        public void Setup()
-        {
-        }
-
-        [Test]
-        public void Test1()
-        {
-            Assert.Pass();
-        }
     }
 }

--- a/SynoAI.Tests/packages.lock.json
+++ b/SynoAI.Tests/packages.lock.json
@@ -1,0 +1,1185 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net7.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.2.0, )",
+        "resolved": "3.2.0",
+        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.4.1, )",
+        "resolved": "17.4.1",
+        "contentHash": "kJ5/v2ad+VEg1fL8UH18nD71Eu+Fq6dM4RKBVqlV2MLSEK/AW4LUkqlk7m7G+BrxEDJVwPjxHam17nldxV80Ow==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.4.1",
+          "Microsoft.TestPlatform.TestHost": "17.4.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, )",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, )",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "MailKit": {
+        "type": "Transitive",
+        "resolved": "3.4.3",
+        "contentHash": "Iewef8mcE1B1LrVudxQjQ0LcriPPeTbxmWMoHQzFS+P6TpEY2eVDbdKdB0Qnbmqr/5w7WfK2mNWuoSX9pI470g==",
+        "dependencies": {
+          "MimeKit": "3.4.3"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.4.1",
+        "contentHash": "T21KxaiFawbrrjm0uXjxAStXaBm5P9H6Nnf8BUtBTvIpd8q57lrChVBCY2dnazmSu9/kuX4z5+kAOT78Dod7vA=="
+      },
+      "Microsoft.Extensions.ApiDescription.Server": {
+        "type": "Transitive",
+        "resolved": "6.0.5",
+        "contentHash": "Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "Nug3rO+7Kl5/SBAadzSMAVgqDlfGjJZ0GenQrLywJ84XGKO0uRqkunz5Wyl0SDwcR71bAATXvSdbdzPrYRYKGw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.4.1",
+        "contentHash": "v2CwoejusooZa/DZYt7UXo+CJOvwAmqg6ZyFJeIBu+DCRDqpEtf7WYhZ/AWii0EKzANPPLU9+m148aipYQkTuA==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.4.1",
+        "contentHash": "K7QXM4P4qrDKdPs/VSEKXR08QEru7daAK8vlIbhwENM3peXJwb9QgrAbtbYyyfVnX+F1m+1hntTH6aRX+h/f8g==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.4.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "gfDtAL1WhkjbRdbZlt/ZeQYCbgRpNCZCGj+yeqHObsNFRDHjq8qZJOX9AyTxJpSRYMi9SJk7JDyAbbVYRgEhAA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "9ZQKCWxH7Ijp9BfahvL2Zyf1cJIk8XYLF6Yjzr2yi0b2cOut/HQ31qf1ThHAgCc3WiZMdnWcfJCgN82/0UunxA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
+      },
+      "MimeKit": {
+        "type": "Transitive",
+        "resolved": "3.4.3",
+        "contentHash": "7TSAcziEwk0bGWODpFTQASghXfYNBBa5VdM8KO4s5SBp5LYgIVXcQsdLBpPQ2XhZW74wfaX8RBUMs1GTMlLJcA==",
+        "dependencies": {
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Security.Cryptography.Pkcs": "6.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0"
+        }
+      },
+      "MQTTnet": {
+        "type": "Transitive",
+        "resolved": "4.1.4.563",
+        "contentHash": "gO9segUcKyQJcjV7w7OOdoAIkec7cUN65vEhYutbdWcj4rbtz/oL/RDvQVVbameXc6ChkjKx7/HbO+R8ejAUZQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "1.6.1",
+        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.2",
+        "contentHash": "R2pZ3B0UjeyHShm9vG+Tu0EBb2lC8b0dFzV9gVn50ofHXh9Smjk6kTn7A/FdAsC8B5cKib1OnGYOXxRBz5XQDg=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "Portable.BouncyCastle": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw=="
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "HdSSp5MnJSsg08KMfZThpuLPJpPwE5hBXvHwoKWosyHHfe8Mh5WKT0ylEOf6yNzX6Ngjxe4Whkafh5q7Ymac4Q=="
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+yH1a49wJMy8Zt4yx5RhJrxO/DBDByAiCzNwiETI+1S4mPdCu0OY4djdciC7Vssk0l22wQaDLrXxXkp+3+7bVA=="
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "c3YNH1GQJbfIPJeCnr4avseugSqPrxwIqzthYyZDN6EuOyNOzq+y2KSUfRcXauya1sF4foESTgwM5e1A8arAKw=="
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "c/qWt2LieNZIj1jGnVNsE2Kl23Ya2aSTBuXMD6V7k9KWr6l16Tqdwq+hJScEpWER9753NWC8h96PaVNY5Ld7Jw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZVuZJqnnegJhd2k/PtAbbIcZ3aZeITq3sj06oKfMBSfphW3HDmk/t4ObvbOk/JA/swGR0LNqMksAh/f7gpTROg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "NS1U+700m4KFRHR5o4vo9DSlTmlCKu/u7dtE5sUHVIPB+xpXxYQvgBgA6wEIeCz6Yfn0Z52/72WYsToCEPJnrw==",
+        "dependencies": {
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "b3pthNgxxFcD+Pc0WSEoC0+md3MyhRS6aCEeenvNE3Fdw1HyJ18ZhRFVJJzIeR/O/jpxPboB805Ho0T3Ul7w8A=="
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KeLz4HClKf+nFS7p/6Fi/CqyLXh81FpiGzcmuS8DGi9lUqSnZ6Es23/gv2O+1XVGfrbNmviF7CckBpavkBoIFQ=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "X7IdhILzr4ROXd8mI1BUCQMSHSQwelUlBjF1JyTKCjXaOGn2fB4EKBxQbCK2VjO3WaWIdlXZL3W6TiIVnrhX4g=="
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "nyFNiCk/r+VOiIqreLix8yN+q3Wga9+SE8BCgkf+2BwEKiNx6DyvFjCgkfV743/grxv8jHJ8gUK4XEQw7yzRYg=="
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ytoewC6wGorL7KoCAvRfsgoJPJbNq+64k2SqW6JcOAebWsFUvCCYgfzQMrnpvPiEl4OrblUlhF2ji+Q1+SVLrQ=="
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "I8bKw2I8k58Wx7fMKQJn2R8lamboCAiHfHeV/pS65ScKWMMI0+wJkLYlEKvgW1D/XvSl/221clBoR2q9QNNM7A=="
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
+      },
+      "SkiaSharp": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "GG8X3EdfwyBfwjl639UIiOVOKEdeoqDgYrz0P1MUCnefXt9cofN+AK8YB/v1+5cLMr03ieWCQdDmPqnFIzSxZw==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "2.88.3",
+          "SkiaSharp.NativeAssets.macOS": "2.88.3"
+        }
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "wz29evZVWRqN7WHfenFwQIgqtr8f5vHCutcl1XuhWrHTRZeaIBk7ngjhyHpjUMcQxtIEAdq34ZRvMQshsBYjqg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.3"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "CEbWAXMGFkPV3S1snBKK7jEG3+xud/9kmSAhu0BEUKKtlMdxx+Qal0U9bntQREM9QpqP5xLWZooodi8IlV8MEg=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "MU4ASL8VAbTv5vSw1PoiWjjjpjtGhWtFYuJnrN4sNHFCePb2ohQij9JhSdqLLxk7RpRtWPdV93fbA53Pt+J0yw=="
+      },
+      "Swashbuckle.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "eUBr4TW0up6oKDA5Xwkul289uqSMgY0xGN4pnbOIBqCcN9VKGGaPvHX3vWaG/hvocfGDP+MGzMA0bBBKz2fkmQ==",
+        "dependencies": {
+          "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+          "Swashbuckle.AspNetCore.Swagger": "6.4.0",
+          "Swashbuckle.AspNetCore.SwaggerGen": "6.4.0",
+          "Swashbuckle.AspNetCore.SwaggerUI": "6.4.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.Swagger": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "nl4SBgGM+cmthUcpwO/w1lUjevdDHAqRvfUoe4Xp/Uvuzt9mzGUwyFCqa3ODBAcZYBiFoKvrYwz0rabslJvSmQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.2.3"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "lXhcUBVqKrPFAQF7e/ZeDfb5PMgE8n5t6L5B6/BQSpiwxgHzmBcx8Msu42zLYFTvR5PIqE9Q9lZvSQAcwCxJjw==",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.4.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "1Hh3atb3pi8c+v7n4/3N80Jj8RvLOXgWxzix6w3OZhB7zBGRwsy7FWr4e3hwgPweSBpwfElqj4V4nkjYabH9nQ=="
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ratu44uTIHgeBeI0dE8DWvmXVBSo4u7ozRZZHOMmK/JPpYyo0dAfgSiHlpiObMQ5lEtEyIXA40sKRYg5J6A8uQ==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ztl69Xp0Y/UXCL+3v3tEU+lIy+bvjKNUmopn1wep/a291pVPK7dxBd6T7WnlQqRog+d1a/hSsgRsmFnIBKTPLQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "KIX+oBU38pxkKPxvLcLfIkOV5Ien8ReN78wro7OF5/erwcmortzeFx+iBswlh2Vz6gVne0khocQudGwaO1Ey6A==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "7.0.0"
+        }
+      },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T6fD00dQ3NTbPDy31m4eQUwKW84s03z0N2C8HpOklyeaDgaJPa/TexP4/SkORMSOwc7WhKifnA6Ya33AkzmafA=="
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GUlBtdOWT4LTV3I+9/PJW+56AnnChTaOqqTLFtdmype/L500M2LIyXgmtd9X2P2VOkmJd5c67H5SaC2QcL1bFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "FhKmdR6MPG+pxow6wGtNAWdZh7noIOpdD5TwQ3CprzgIE1bBBoim0vbR1+AWsWjQmU7zXHgQo4TWSP6lCeiWcQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Buffers": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+        "dependencies": {
+          "System.Buffers": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Net.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qOu+hDwFwoZPbzPvwut2qATe3ygjeQBDQj91xlsaqGFQUI5i4ZnZb8yyQuLGpDGivEPIt8EJkd1BVzVoP31FXA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Net.Sockets": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7u6ulLcZbyxB5Gq0nMkQttcdBTx57ibzw+4IOXEfR+sXYQoHvjW5LTLyNr8O22UIMrqYbchJQJnos4eooYzYJA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OKiSUN7DmTWeYb3l51A7EYaeNMnvxwE249YtZz7yooT4gOZhmTjIn48KgSsw2k2lYdLgTKNJw/ZIfSElwDRVgg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "uv1ynXqiMK8mp1GM3jDqPCFN66eJ5w5XNomaK2XD+TuCroNTLFGeZ+WCmBMcBDyTFKou3P6cR6J/QsaqDp7fGQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "03idZOqFlsKRL4W+LuCpJ6dBYDUWReug6lZjBa3uJWnk5sPCUXckocevTaUA8iT/MFSrY/2HXkOt753xQ/cf8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "X4s/FCkEUnRGnwR3aSfVIkldBmtURMhmexALNTwpjklzxWU7yjMk7GHLKOZTNkgnWnE0q7+BCf9N2LVRWxewaA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "elM3x+xSRhzQysiqo85SbidJJ2YbZlnvmh+53TuSZHsD7dNuuEWser+9EFtY+rYupBwkq2avc6ZCO3/6qACgmg==",
+        "dependencies": {
+          "System.Formats.Asn1": "6.0.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.3.0",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "YVMK0Bt/A43RmwizJoZ22ei2nmrhobgeiYwFzC4YAN+nue8RF6djXDMog0UCn+brerQoYVyaS+ghy9P/MUVcmw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.3.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "Telegram.Bot": {
+        "type": "Transitive",
+        "resolved": "18.0.0",
+        "contentHash": "BD0UchUXINymCGS+1O1tv2enCRyv+VbSJQAgfnueTZs3j7K4XXyJyW0CgyJleTrqB1oq1hS1ux6gBpi3Ajp+ZQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.2"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "synoai": {
+        "type": "Project",
+        "dependencies": {
+          "MQTTnet": "[4.1.4.563, )",
+          "MailKit": "[3.4.3, )",
+          "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.17.0, )",
+          "Newtonsoft.Json": "[13.0.2, )",
+          "SkiaSharp": "[2.88.3, )",
+          "SkiaSharp.NativeAssets.Linux": "[2.88.3, )",
+          "Swashbuckle.AspNetCore": "[6.4.0, )",
+          "System.Drawing.Common": "[7.0.0, )",
+          "Telegram.Bot": "[18.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/SynoAI/AIs/AI.cs
+++ b/SynoAI/AIs/AI.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.AIs
 {
-    public abstract class AI
+    internal abstract class AI
     {
         public abstract Task<IEnumerable<AIPrediction>> Process(ILogger logger, Camera camera, byte[] image);
     }

--- a/SynoAI/AIs/AI.cs
+++ b/SynoAI/AIs/AI.cs
@@ -1,9 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using SynoAI.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using SynoAI.Models;
 
 namespace SynoAI.AIs
 {

--- a/SynoAI/AIs/AIType.cs
+++ b/SynoAI/AIs/AIType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.AIs
+﻿namespace SynoAI.AIs
 {
     /// <summary>
     /// A list of support AI types.

--- a/SynoAI/AIs/DeepStack/DeepStackAI.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackAI.cs
@@ -1,14 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using SynoAI.App;
 using SynoAI.Models;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace SynoAI.AIs.DeepStack
 {
@@ -85,7 +78,9 @@ namespace SynoAI.AIs.DeepStack
         /// <summary>
         /// Fetches the response content and parses it a DeepStack object.
         /// </summary>
+        /// <param name="camera"></param>
         /// <param name="message">The message to parse.</param>
+        /// <param name="logger"></param>
         /// <returns>A usable object.</returns>
         private async Task<DeepStackResponse> GetResponse(ILogger logger, Camera camera, HttpResponseMessage message)
         {

--- a/SynoAI/AIs/DeepStack/DeepStackAI.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackAI.cs
@@ -5,9 +5,9 @@ using System.Diagnostics;
 
 namespace SynoAI.AIs.DeepStack
 {
-    public class DeepStackAI : AI
+    internal class DeepStackAI : AI
     {
-        public async override Task<IEnumerable<AIPrediction>> Process(ILogger logger, Camera camera, byte[] image)
+        public override async Task<IEnumerable<AIPrediction>> Process(ILogger logger, Camera camera, byte[] image)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
 
@@ -69,7 +69,7 @@ namespace SynoAI.AIs.DeepStack
         /// <param name="basePath"></param>
         /// <param name="resourcePath"></param>
         /// <returns>A <see cref="Uri"/> for the combined base and resource.</returns>
-        protected Uri GetUri(string basePath, string resourcePath)
+        protected static Uri GetUri(string basePath, string resourcePath)
         {
             Uri baseUri = new(basePath);
             return new Uri(baseUri, resourcePath);
@@ -82,7 +82,7 @@ namespace SynoAI.AIs.DeepStack
         /// <param name="message">The message to parse.</param>
         /// <param name="logger"></param>
         /// <returns>A usable object.</returns>
-        private async Task<DeepStackResponse> GetResponse(ILogger logger, Camera camera, HttpResponseMessage message)
+        private static async Task<DeepStackResponse> GetResponse(ILogger logger, Camera camera, HttpResponseMessage message)
         {
             string content = await message.Content.ReadAsStringAsync();                
             logger.LogDebug($"{camera.Name}: DeepStackAI: Responded with {content}.");

--- a/SynoAI/AIs/DeepStack/DeepStackPrediction.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackPrediction.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.AIs.DeepStack
 {

--- a/SynoAI/AIs/DeepStack/DeepStackRequest.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackRequest.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.AIs.DeepStack
 {

--- a/SynoAI/AIs/DeepStack/DeepStackResponse.cs
+++ b/SynoAI/AIs/DeepStack/DeepStackResponse.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace SynoAI.AIs.DeepStack
+﻿namespace SynoAI.AIs.DeepStack
 {
     /// <summary>
     /// An object representing a response from DeepStack.

--- a/SynoAI/App/HttpClientWrapper.cs
+++ b/SynoAI/App/HttpClientWrapper.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-
-namespace SynoAI.App
+﻿namespace SynoAI.App
 {
     public class HttpClientWrapper : HttpClient, IHttpClient
     {

--- a/SynoAI/App/HttpClientWrapper.cs
+++ b/SynoAI/App/HttpClientWrapper.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.App
 {
-    public class HttpClientWrapper : HttpClient, IHttpClient
+    internal class HttpClientWrapper : HttpClient, IHttpClient
     {
     }
 }

--- a/SynoAI/App/IHttpClient.cs
+++ b/SynoAI/App/IHttpClient.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
-
-namespace SynoAI.App
+﻿namespace SynoAI.App
 {
     public interface IHttpClient
     {

--- a/SynoAI/App/Shared.cs
+++ b/SynoAI/App/Shared.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.App
 {
-    public static class Shared
+    internal static class Shared
     {
         public static IHttpClient HttpClient = new HttpClientWrapper();
     }

--- a/SynoAI/App/Shared.cs
+++ b/SynoAI/App/Shared.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-
-namespace SynoAI.App
+﻿namespace SynoAI.App
 {
     public static class Shared
     {

--- a/SynoAI/Config.cs
+++ b/SynoAI/Config.cs
@@ -8,7 +8,7 @@ namespace SynoAI
     /// <summary>
     /// Represents the system configuration.
     /// </summary>
-    public static class Config
+    internal static class Config
     {
         /// <summary>
         /// The URL to the synology API.

--- a/SynoAI/Config.cs
+++ b/SynoAI/Config.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using SkiaSharp;
+﻿using SkiaSharp;
 using SynoAI.AIs;
 using SynoAI.Models;
 using SynoAI.Notifiers;
-using System;
-using System.Collections.Generic;
 
 namespace SynoAI
 {
@@ -177,6 +173,7 @@ namespace SynoAI
         /// <summary>
         /// Generates the configuration from the provided IConfiguration.
         /// </summary>
+        /// <param name="logger"></param>
         /// <param name="configuration">The configuration from which to pull the values.</param>
         public static void Generate(ILogger logger, IConfiguration configuration)
         {

--- a/SynoAI/Constants.cs
+++ b/SynoAI/Constants.cs
@@ -1,6 +1,6 @@
 namespace SynoAI
 {
-    public static class Constants
+    internal static class Constants
     {
         public const string DIRECTORY_CAPTURES = "Captures";
     }

--- a/SynoAI/Controllers/CameraController.cs
+++ b/SynoAI/Controllers/CameraController.cs
@@ -1,17 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using SynoAI.Models;
 using SynoAI.Notifiers;
 using SynoAI.Services;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using SynoAI.Extensions;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using SynoAI.Hubs;
 using System.Drawing;
@@ -34,10 +27,10 @@ namespace SynoAI.Controllers
         private readonly ISynologyService _synologyService;
         private readonly ILogger<CameraController> _logger;
 
-        private static ConcurrentDictionary<string, bool> _runningCameraChecks = new(StringComparer.OrdinalIgnoreCase);
-        private static ConcurrentDictionary<string, DateTime> _delayedCameraChecks = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, bool> _runningCameraChecks = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, DateTime> _delayedCameraChecks = new(StringComparer.OrdinalIgnoreCase);
 
-        private static ConcurrentDictionary<string, bool> _enabledCameras = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, bool> _enabledCameras = new(StringComparer.OrdinalIgnoreCase);
 
         public CameraController(IAIService aiService, ISynologyService synologyService, ILogger<CameraController> logger, IHubContext<SynoAIHub> hubContext)
         {

--- a/SynoAI/Controllers/CameraController.cs
+++ b/SynoAI/Controllers/CameraController.cs
@@ -182,8 +182,8 @@ namespace SynoAI.Controllers
 
                     // Save the original unprocessed image if required
                     if (Config.SaveOriginalSnapshot == SaveSnapshotMode.Always ||
-                        (Config.SaveOriginalSnapshot == SaveSnapshotMode.WithPredictions && predictions.Count() > 0) ||
-                        (Config.SaveOriginalSnapshot == SaveSnapshotMode.WithValidPredictions && validPredictions.Count() > 0))
+                        (Config.SaveOriginalSnapshot == SaveSnapshotMode.WithPredictions && predictions.Any()) ||
+                        (Config.SaveOriginalSnapshot == SaveSnapshotMode.WithValidPredictions && validPredictions.Any()))
                     {
                         _logger.LogInformation($"{id}: Saving original image");
                         SnapshotManager.SaveOriginalImage(_logger, camera, snapshot);
@@ -271,7 +271,7 @@ namespace SynoAI.Controllers
         private bool ShouldIncludePrediction(string id, Camera camera, Stopwatch overallStopwatch, AIPrediction prediction)
         {
             // Check if the prediction falls within the exclusion zones
-            if (camera.Exclusions != null && camera.Exclusions.Count() > 0)
+            if (camera.Exclusions != null && camera.Exclusions.Any())
             {
                 Rectangle boundary = new(prediction.MinX, prediction.MinY, prediction.SizeX, prediction.SizeY);
                 foreach (Zone exclusion in camera.Exclusions)
@@ -390,7 +390,7 @@ namespace SynoAI.Controllers
         /// <param name="bitmap">The bitmap to rotate.</param>
         /// <param name="angle">The angle to rotate to.</param>
         /// <returns>The rotated bitmap.</returns>
-        private SKBitmap Rotate(SKBitmap bitmap, double angle)
+        private static SKBitmap Rotate(SKBitmap bitmap, double angle)
         {
             double radians = Math.PI * angle / 180;
             float sine = (float)Math.Abs(Math.Sin(radians));

--- a/SynoAI/Controllers/HomeController.cs
+++ b/SynoAI/Controllers/HomeController.cs
@@ -253,7 +253,7 @@ namespace SynoAI.Controllers
             if (index != -1)
             {
                 //try to extract the number of valid objects predicted inside this snapshot
-                if (!int.TryParse(name.Substring(index + 1), out objects))
+                if (!int.TryParse(name.AsSpan(index + 1), out objects))
                     objects = 0;
             }
             else

--- a/SynoAI/Controllers/HomeController.cs
+++ b/SynoAI/Controllers/HomeController.cs
@@ -1,17 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
-using System.IO;
 using SynoAI.Models;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 
-using System.Linq;
-
 namespace SynoAI.Controllers
 {
-
     public class HomeController : Controller
     {
         static readonly string[] byteSizes = { "bytes", "Kb", "Mb", "Gb", "Tb" };
@@ -63,7 +57,7 @@ namespace SynoAI.Controllers
   
             try 
             {
-                ViewData["date"] = new DateTime(Int16.Parse(year),Int16.Parse(month),Int16.Parse(day),Int16.Parse(hour),Int16.Parse(minute),59,999);;
+                ViewData["date"] = new DateTime(Int16.Parse(year),Int16.Parse(month),Int16.Parse(day),Int16.Parse(hour),Int16.Parse(minute),59,999);
             }
             catch (Exception) 
             {
@@ -75,8 +69,8 @@ namespace SynoAI.Controllers
 
         /// <summary>
         /// Return snapshot image as JPEG, either in original size or a scaled down version, if asked.
-        //// In order to use System.Drawing.Common
-        //// In Terminal, issue: dotnet add SynoAI package System.Drawing.Common
+        /// In order to use System.Drawing.Common
+        /// In Terminal, issue: dotnet add SynoAI package System.Drawing.Common
         /// </summary>
         [Route("{cameraName}/{filename}/{width}")]
         [Route("{cameraName}/{filename}")]
@@ -149,7 +143,7 @@ namespace SynoAI.Controllers
 
                 //User is asking for global 24 hours report, so I also meter the general storage / snapshots / hours counters.
                 if (!GraphHour)
-                    data.Snapshots = snapshots.Count();
+                    data.Snapshots = snapshots.Length;
 
                 foreach (FileInfo snapshot in snapshots) 
                 {
@@ -315,7 +309,7 @@ namespace SynoAI.Controllers
         /// </summary>
         public static string GetTypes(Camera camera) 
         {
-            if (camera.Types.Count() == 0) 
+            if (!camera.Types.Any()) 
             {
                  return "Any";
             }

--- a/SynoAI/Controllers/ImageController.cs
+++ b/SynoAI/Controllers/ImageController.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using System.IO;
 
 namespace SynoAI.Controllers
 {

--- a/SynoAI/Dockerfile
+++ b/SynoAI/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 RUN apt-get update && apt-get install -y libgdiplus
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["SynoAI.csproj", "./"]
 RUN dotnet restore "SynoAI.csproj"

--- a/SynoAI/Extensions/StringExtensions.cs
+++ b/SynoAI/Extensions/StringExtensions.cs
@@ -1,13 +1,13 @@
 namespace SynoAI.Extensions
 {
-    public static class StringExtensions
+    internal static class StringExtensions
     {
         public static string FirstCharToUpper(this string input) =>
             input switch
             {
                 null => throw new ArgumentNullException(nameof(input)),
                 "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
-                _ => input.First().ToString().ToUpper() + input.Substring(1)
+                _ => string.Concat(input.First().ToString().ToUpper(), input.AsSpan(1))
             };
     }
 }

--- a/SynoAI/Extensions/StringExtensions.cs
+++ b/SynoAI/Extensions/StringExtensions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-
 namespace SynoAI.Extensions
 {
     public static class StringExtensions

--- a/SynoAI/Hubs/SynoAIHub.cs
+++ b/SynoAI/Hubs/SynoAIHub.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.SignalR;
-using System.Threading.Tasks;
 
 namespace SynoAI.Hubs
 {

--- a/SynoAI/Models/AIPrediction.cs
+++ b/SynoAI/Models/AIPrediction.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     public class AIPrediction
     {

--- a/SynoAI/Models/Camera.cs
+++ b/SynoAI/Models/Camera.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     /// <summary>
     /// Represents a camera object.

--- a/SynoAI/Models/Camera.cs
+++ b/SynoAI/Models/Camera.cs
@@ -115,6 +115,7 @@
             return DelayAfterSuccess ?? Config.DelayAfterSuccess ?? GetDelay();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name;

--- a/SynoAI/Models/CameraQuality.cs
+++ b/SynoAI/Models/CameraQuality.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Models
 {
-    public enum CameraQuality
+    internal enum CameraQuality
     {
         High = 0,
         Balanced = 1,

--- a/SynoAI/Models/DTOs/UpdateDto.cs
+++ b/SynoAI/Models/DTOs/UpdateDto.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
-using System;
 
 namespace SynoAI.Models.DTOs
 {

--- a/SynoAI/Models/Graph.cs
+++ b/SynoAI/Models/Graph.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace SynoAI.Models
 {
     /// <summary>
@@ -155,7 +152,7 @@ namespace SynoAI.Models
 
 
         /// <summary>
-        /// Since Y axis shows <NumberOfSteps> reference values, if there are less than GraphYSteps snapshots, we need to adjust way of displaying the y-axis ref
+        /// Since Y axis shows 'NumberOfSteps' reference values, if there are less than GraphYSteps snapshots, we need to adjust way of displaying the y-axis ref
         /// </summary>
         public String yStepping(int yMax, int Step) 
         {

--- a/SynoAI/Models/Notification.cs
+++ b/SynoAI/Models/Notification.cs
@@ -1,7 +1,4 @@
 ﻿using SynoAI.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SynoAI.Models
 {
@@ -30,7 +27,6 @@ namespace SynoAI.Models
         /// <summary>
         /// Gets the labels from the predictions to use in the notifications.
         /// </summary>
-        /// <param name="validPredictions">The predictions to process.</param>
         /// <returns>A list of labels.</returns>
         private IEnumerable<string> GetLabels()
         {

--- a/SynoAI/Models/Notification.cs
+++ b/SynoAI/Models/Notification.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Models
 {
-    public class Notification
+    internal class Notification
     {
         /// <summary>
         /// Object for fetching the processed image

--- a/SynoAI/Models/ProcessedImage.cs
+++ b/SynoAI/Models/ProcessedImage.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace SynoAI.Models
 {
     /// <summary>

--- a/SynoAI/Models/ProcessedImage.cs
+++ b/SynoAI/Models/ProcessedImage.cs
@@ -14,6 +14,11 @@ namespace SynoAI.Models
         /// </summary>
         public readonly string FileName;
 
+        /// <summary>
+        /// Create a ProcessedImage
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <exception cref="ArgumentNullException">When filePath is null</exception>
         public ProcessedImage(string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentNullException(nameof(filePath));

--- a/SynoAI/Models/SaveSnapshotMode.cs
+++ b/SynoAI/Models/SaveSnapshotMode.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Models
 {
-    public enum SaveSnapshotMode
+    internal enum SaveSnapshotMode
     {
         /// <summary>
         /// The snapshots are never saved.

--- a/SynoAI/Models/SynologyApiInfoResponse.cs
+++ b/SynoAI/Models/SynologyApiInfoResponse.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace SynoAI.Models
 {
     public class SynologyApiInfoResponse : Dictionary<string, SynologyApiInfo>

--- a/SynoAI/Models/SynologyApiInfoResponse.cs
+++ b/SynoAI/Models/SynologyApiInfoResponse.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Models
 {
-    public class SynologyApiInfoResponse : Dictionary<string, SynologyApiInfo>
+    internal class SynologyApiInfoResponse : Dictionary<string, SynologyApiInfo>
     {
     }
 }

--- a/SynoAI/Models/SynologyCamera.cs
+++ b/SynoAI/Models/SynologyCamera.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace SynoAI.Models
 {

--- a/SynoAI/Models/SynologyCameras.cs
+++ b/SynoAI/Models/SynologyCameras.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Models
 {
-    public class SynologyCameras
+    internal class SynologyCameras
     {
         public IEnumerable<SynologyCamera> Cameras { get; set; }
     }

--- a/SynoAI/Models/SynologyCameras.cs
+++ b/SynoAI/Models/SynologyCameras.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     public class SynologyCameras
     {

--- a/SynoAI/Models/SynologyError.cs
+++ b/SynoAI/Models/SynologyError.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Models
 {
-    public class SynologyError
+    internal class SynologyError
     {
         public string Code { get; set; }
     }

--- a/SynoAI/Models/SynologyError.cs
+++ b/SynoAI/Models/SynologyError.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     public class SynologyError
     {

--- a/SynoAI/Models/SynologyLogin.cs
+++ b/SynoAI/Models/SynologyLogin.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Models
 {
-    public class SynologyLogin
+    internal class SynologyLogin
     {
         public string SID { get; set; }
     }

--- a/SynoAI/Models/SynologyLogin.cs
+++ b/SynoAI/Models/SynologyLogin.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     public class SynologyLogin
     {

--- a/SynoAI/Models/SynologyResponse.cs
+++ b/SynoAI/Models/SynologyResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Models
+﻿namespace SynoAI.Models
 {
     public class SynologyResponse<T> : SynologyResponse
     {

--- a/SynoAI/Models/SynologyResponse.cs
+++ b/SynoAI/Models/SynologyResponse.cs
@@ -1,11 +1,11 @@
 ﻿namespace SynoAI.Models
 {
-    public class SynologyResponse<T> : SynologyResponse
+    internal class SynologyResponse<T> : SynologyResponse
     {
         public T Data { get; set; }
     }
 
-    public class SynologyResponse
+    internal class SynologyResponse
     {
         public bool Success { get; set; }
         public SynologyError Error { get; set; }

--- a/SynoAI/Notifiers/Discord/Discord.cs
+++ b/SynoAI/Notifiers/Discord/Discord.cs
@@ -3,7 +3,7 @@ using SynoAI.Models;
 
 namespace SynoAI.Notifiers.Discord
 {
-    public class Discord : NotifierBase
+    internal class Discord : NotifierBase
     {
         /// <summary>
         /// Discord Webhook Url.
@@ -25,7 +25,7 @@ namespace SynoAI.Notifiers.Discord
             HttpResponseMessage responseMessage = await Shared.HttpClient.PostAsync(Url, formData);
             if (responseMessage.IsSuccessStatusCode)
             {
-                logger.LogInformation($"{camera.Name}: Discord: Notification sent successfully");
+                logger.LogInformation("{CameraName}: Discord: Notification sent successfully", camera.Name);
             }
             else
             {

--- a/SynoAI/Notifiers/Discord/Discord.cs
+++ b/SynoAI/Notifiers/Discord/Discord.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using SynoAI.App;
+﻿using SynoAI.App;
 using SynoAI.Models;
 
 namespace SynoAI.Notifiers.Discord

--- a/SynoAI/Notifiers/Discord/DiscordFactory.cs
+++ b/SynoAI/Notifiers/Discord/DiscordFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Notifiers.Discord
 {
-    public class DiscordFactory : NotifierFactory
+    internal class DiscordFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/Discord/DiscordFactory.cs
+++ b/SynoAI/Notifiers/Discord/DiscordFactory.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-
-namespace SynoAI.Notifiers.Discord
+﻿namespace SynoAI.Notifiers.Discord
 {
     public class DiscordFactory : NotifierFactory
     {

--- a/SynoAI/Notifiers/Email/Email.cs
+++ b/SynoAI/Notifiers/Email/Email.cs
@@ -1,18 +1,7 @@
 using MailKit.Net.Smtp;
 using MailKit.Security;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using MimeKit;
-using MimeKit.Text;
-using Newtonsoft.Json;
 using SynoAI.Models;
-using SynoAI.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Email
 {

--- a/SynoAI/Notifiers/Email/Email.cs
+++ b/SynoAI/Notifiers/Email/Email.cs
@@ -8,7 +8,7 @@ namespace SynoAI.Notifiers.Email
     /// <summary>
     /// Calls a third party API.
     /// </summary>
-    public class Email : NotifierBase
+    internal class Email : NotifierBase
     {
         /// <summary>
         /// The email address to send the notification from.

--- a/SynoAI/Notifiers/Email/EmailFactory.cs
+++ b/SynoAI/Notifiers/Email/EmailFactory.cs
@@ -2,7 +2,7 @@ using MailKit.Security;
 
 namespace SynoAI.Notifiers.Email
 {
-    public class EmailFactory : NotifierFactory
+    internal class EmailFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {
@@ -31,7 +31,7 @@ namespace SynoAI.Notifiers.Email
             }
         }
 
-        private SecureSocketOptions GetSecureSocketOptions(ILogger logger, IConfigurationSection section)
+        private static SecureSocketOptions GetSecureSocketOptions(ILogger logger, IConfigurationSection section)
         {
             string options = section.GetValue<string>("Encryption", "None").ToUpper();
 

--- a/SynoAI/Notifiers/Email/EmailFactory.cs
+++ b/SynoAI/Notifiers/Email/EmailFactory.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Net.Http;
 using MailKit.Security;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace SynoAI.Notifiers.Email
 {

--- a/SynoAI/Notifiers/INotifier.cs
+++ b/SynoAI/Notifiers/INotifier.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers
 {
-    public interface INotifier
+    internal interface INotifier
     {
         /// <summary>
         /// The list of camera names that the notifier is for.

--- a/SynoAI/Notifiers/INotifier.cs
+++ b/SynoAI/Notifiers/INotifier.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using SynoAI.Models;
-using SynoAI.Services;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using SynoAI.Models;
 
 namespace SynoAI.Notifiers
 {

--- a/SynoAI/Notifiers/Mqtt/Mqtt.cs
+++ b/SynoAI/Notifiers/Mqtt/Mqtt.cs
@@ -7,7 +7,7 @@ namespace SynoAI.Notifiers.Mqtt
     /// <summary>
     /// Sends a message over MQTT.
     /// </summary>
-    public sealed class Mqtt : NotifierBase
+    internal sealed class Mqtt : NotifierBase
     {
         /// <summary>
         /// The username when using Basic authentication.

--- a/SynoAI/Notifiers/Mqtt/Mqtt.cs
+++ b/SynoAI/Notifiers/Mqtt/Mqtt.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
-using SynoAI.Models;
-using System.Threading.Tasks;
+﻿using SynoAI.Models;
 using MQTTnet.Client;
 using MQTTnet;
-using System.Threading;
-using System;
 
 namespace SynoAI.Notifiers.Mqtt
 {

--- a/SynoAI/Notifiers/Mqtt/MqttFactory.cs
+++ b/SynoAI/Notifiers/Mqtt/MqttFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Notifiers.Mqtt
 {
-    public class MqttFactory : NotifierFactory
+    internal class MqttFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/Mqtt/MqttFactory.cs
+++ b/SynoAI/Notifiers/Mqtt/MqttFactory.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using SynoAI.Notifiers.Webhook;
-
-namespace SynoAI.Notifiers.Mqtt
+﻿namespace SynoAI.Notifiers.Mqtt
 {
     public class MqttFactory : NotifierFactory
     {

--- a/SynoAI/Notifiers/NotifierBase.cs
+++ b/SynoAI/Notifiers/NotifierBase.cs
@@ -4,7 +4,7 @@ using SynoAI.Models;
 
 namespace SynoAI.Notifiers
 {
-    public abstract class NotifierBase : INotifier
+    internal abstract class NotifierBase : INotifier
     {
         public IEnumerable<string> Cameras { get; set; } 
         public IEnumerable<string> Types { get; set; } 
@@ -16,7 +16,7 @@ namespace SynoAI.Notifiers
 
         public virtual Task CleanupAsync(ILogger logger) { return Task.CompletedTask; }
 
-        protected string GetMessage(Camera camera, IEnumerable<string> foundTypes, string errorMessage = null)
+        protected static string GetMessage(Camera camera, IEnumerable<string> foundTypes, string errorMessage = null)
         {
             string result ;
             if (Config.AlternativeLabelling && Config.DrawMode == DrawMode.Matches)
@@ -53,7 +53,7 @@ namespace SynoAI.Notifiers
             return result;
         }
 
-        protected string GetImageUrl(Camera camera, Notification notification)
+        protected static string GetImageUrl(Camera camera, Notification notification)
         {
             if (Config.SynoAIUrL == null)
             {
@@ -69,7 +69,7 @@ namespace SynoAI.Notifiers
         /// <summary>
         /// Generates a JSON representation of the notification.
         /// </summary>
-        protected string GenerateJSON(Camera camera, Notification notification, bool sendImage)
+        protected static string GenerateJSON(Camera camera, Notification notification, bool sendImage)
         {
             dynamic jsonObject = new ExpandoObject();
 
@@ -95,7 +95,7 @@ namespace SynoAI.Notifiers
         /// <summary>
         /// Returns FileStream data as a base64-encoded string
         /// </summary>
-        private string ToBase64String(FileStream fileStream)
+        private static string ToBase64String(FileStream fileStream)
         {
             byte[] buffer = new byte[fileStream.Length];
             fileStream.Read(buffer, 0, (int)fileStream.Length);
@@ -108,7 +108,7 @@ namespace SynoAI.Notifiers
         /// </summary>
         /// <param name="message">The message to parse.</param>
         /// <returns>A usable object.</returns>
-        protected async Task<T> GetResponse<T>(HttpResponseMessage message)
+        protected static async Task<T> GetResponse<T>(HttpResponseMessage message)
         {
             string content = await message.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<T>(content);

--- a/SynoAI/Notifiers/NotifierBase.cs
+++ b/SynoAI/Notifiers/NotifierBase.cs
@@ -1,14 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Dynamic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SynoAI.Models;
-using SynoAI.Services;
 
 namespace SynoAI.Notifiers
 {

--- a/SynoAI/Notifiers/NotifierFactory.cs
+++ b/SynoAI/Notifiers/NotifierFactory.cs
@@ -12,7 +12,7 @@ namespace SynoAI.Notifiers
     /// <summary>
     /// Handles the construction of the notifiers.
     /// </summary>
-    public abstract class NotifierFactory
+    internal abstract class NotifierFactory
     {
         public abstract INotifier Create(ILogger logger, IConfigurationSection section);
 

--- a/SynoAI/Notifiers/NotifierFactory.cs
+++ b/SynoAI/Notifiers/NotifierFactory.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using SynoAI.Notifiers.Email;
+﻿using SynoAI.Notifiers.Email;
 using SynoAI.Notifiers.Pushbullet;
 using SynoAI.Notifiers.Pushover;
 using SynoAI.Notifiers.SynologyChat;
@@ -8,8 +6,6 @@ using SynoAI.Notifiers.Telegram;
 using SynoAI.Notifiers.Webhook;
 using SynoAI.Notifiers.Discord;
 using SynoAI.Notifiers.Mqtt;
-using System;
-using System.Collections.Generic;
 
 namespace SynoAI.Notifiers
 {

--- a/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
+++ b/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
@@ -8,7 +8,7 @@ namespace SynoAI.Notifiers.Pushbullet
     /// Configuration for sending a Pushbullet notification.
     /// https://docs.pushbullet.com/
     /// </summary>
-    public class Pushbullet : NotifierBase
+    internal class Pushbullet : NotifierBase
     {
         //private const int MAX_FILE_SIZE = 26214400;
 

--- a/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
+++ b/SynoAI/Notifiers/Pushbullet/Pushbullet.cs
@@ -1,14 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using SynoAI.App;
 using SynoAI.Models;
-using SynoAI.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushbullet
 {
@@ -32,6 +24,7 @@ namespace SynoAI.Notifiers.Pushbullet
         /// Sends a message and an image using the Pushbullet API.
         /// </summary>
         /// <param name="camera">The camera that triggered the notification.</param>
+        /// <param name="notification"></param>
         /// <param name="logger">A logger.</param>
         public override async Task SendAsync(Camera camera, Notification notification, ILogger logger)
         {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletError.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletError.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Notifiers.Pushbullet
 {
-    public class PushbulletError
+    internal class PushbulletError
     {
         public string Code { get; set; }
         public string Type { get; set; }

--- a/SynoAI/Notifiers/Pushbullet/PushbulletError.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletError.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SynoAI.Notifiers.Pushbullet
+﻿namespace SynoAI.Notifiers.Pushbullet
 {
     public class PushbulletError
     {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletErrorResponse.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletErrorResponse.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers.Pushbullet
 {
-    public class PushbulletErrorResponse
+    internal class PushbulletErrorResponse
     {
         public PushbulletError Error { get; set; }
         [JsonProperty("error_code")]

--- a/SynoAI/Notifiers/Pushbullet/PushbulletErrorResponse.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletErrorResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushbullet
 {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletFactory.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Notifiers.Pushbullet
 {
-    public class PushbulletFactory : NotifierFactory
+    internal class PushbulletFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletFactory.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletFactory.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-
-namespace SynoAI.Notifiers.Pushbullet
+﻿namespace SynoAI.Notifiers.Pushbullet
 {
     public class PushbulletFactory : NotifierFactory
     {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletPush.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletPush.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers.Pushbullet
 {
-    public class PushbulletPush
+    internal class PushbulletPush
     {
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/SynoAI/Notifiers/Pushbullet/PushbulletPush.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletPush.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushbullet
 {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletUploadRequest.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletUploadRequest.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushbullet
 {

--- a/SynoAI/Notifiers/Pushbullet/PushbulletUploadRequestResponse.cs
+++ b/SynoAI/Notifiers/Pushbullet/PushbulletUploadRequestResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushbullet
 {

--- a/SynoAI/Notifiers/Pushover/Pushover.cs
+++ b/SynoAI/Notifiers/Pushover/Pushover.cs
@@ -1,16 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using SynoAI.App;
+﻿using SynoAI.App;
 using SynoAI.Models;
-using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Pushover
 {

--- a/SynoAI/Notifiers/Pushover/Pushover.cs
+++ b/SynoAI/Notifiers/Pushover/Pushover.cs
@@ -4,7 +4,7 @@ using System.Net.Http.Headers;
 
 namespace SynoAI.Notifiers.Pushover
 {
-    public class Pushover : NotifierBase
+    internal class Pushover : NotifierBase
     {
         private readonly string URI_MESSAGE = "https://api.pushover.net/1/messages.json";
 

--- a/SynoAI/Notifiers/Pushover/PushoverFactory.cs
+++ b/SynoAI/Notifiers/Pushover/PushoverFactory.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-
-namespace SynoAI.Notifiers.Pushover
+﻿namespace SynoAI.Notifiers.Pushover
 {
     public class PushoverFactory : NotifierFactory
     {

--- a/SynoAI/Notifiers/Pushover/PushoverFactory.cs
+++ b/SynoAI/Notifiers/Pushover/PushoverFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace SynoAI.Notifiers.Pushover
 {
-    public class PushoverFactory : NotifierFactory
+    internal class PushoverFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/SynologyChat/SynologyChat.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChat.cs
@@ -1,16 +1,5 @@
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SynoAI.Models;
-using SynoAI.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.SynologyChat
 {

--- a/SynoAI/Notifiers/SynologyChat/SynologyChat.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChat.cs
@@ -6,7 +6,7 @@ namespace SynoAI.Notifiers.SynologyChat
     /// <summary>
     /// Calls a third party API.
     /// </summary>
-    public class SynologyChat : NotifierBase
+    internal class SynologyChat : NotifierBase
     {
         /// <summary>
         /// The URL to send the request to including the token.

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatErrorReasonResponse.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatErrorReasonResponse.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers.SynologyChat
 {
-    public class SynologyChatErrorReasonResponse
+    internal class SynologyChatErrorReasonResponse
     {
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatErrorResponse.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatErrorResponse.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers.SynologyChat
 {
-    public class SynologyChatErrorResponse
+    internal class SynologyChatErrorResponse
     {
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatErrorResponse.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatErrorResponse.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace SynoAI.Notifiers.SynologyChat
 {

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatFactory.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatFactory.cs
@@ -1,6 +1,3 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-
 namespace SynoAI.Notifiers.SynologyChat
 {
     public class SynologyChatFactory : NotifierFactory

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatFactory.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatFactory.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Notifiers.SynologyChat
 {
-    public class SynologyChatFactory : NotifierFactory
+    internal class SynologyChatFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/SynologyChat/SynologyChatResponse.cs
+++ b/SynoAI/Notifiers/SynologyChat/SynologyChatResponse.cs
@@ -2,7 +2,7 @@
 
 namespace SynoAI.Notifiers.SynologyChat
 {
-    public class SynologyChatResponse
+    internal class SynologyChatResponse
     {
         [JsonProperty("success")]
         public bool Success { get; set; }

--- a/SynoAI/Notifiers/Telegram/Telegram.cs
+++ b/SynoAI/Notifiers/Telegram/Telegram.cs
@@ -6,7 +6,7 @@ namespace SynoAI.Notifiers.Telegram
     /// <summary>
     /// Calls a third party API.
     /// </summary>
-    public class Telegram : NotifierBase
+    internal class Telegram : NotifierBase
     {
         /// <summary>
         /// The ID of the chat to send notifications to

--- a/SynoAI/Notifiers/Telegram/Telegram.cs
+++ b/SynoAI/Notifiers/Telegram/Telegram.cs
@@ -1,18 +1,4 @@
-using MailKit.Net.Smtp;
-using MailKit.Security;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using MimeKit;
-using MimeKit.Text;
-using Newtonsoft.Json;
 using SynoAI.Models;
-using SynoAI.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Telegram.Bot;
 
 namespace SynoAI.Notifiers.Telegram

--- a/SynoAI/Notifiers/Telegram/TelegramFactory.cs
+++ b/SynoAI/Notifiers/Telegram/TelegramFactory.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Net.Http;
-using MailKit.Security;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-
 namespace SynoAI.Notifiers.Telegram
 {
     public class TelegramFactory : NotifierFactory

--- a/SynoAI/Notifiers/Telegram/TelegramFactory.cs
+++ b/SynoAI/Notifiers/Telegram/TelegramFactory.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Notifiers.Telegram
 {
-    public class TelegramFactory : NotifierFactory
+    internal class TelegramFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/Webhook/AuthorizationMethod.cs
+++ b/SynoAI/Notifiers/Webhook/AuthorizationMethod.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Notifiers.Webhook
 {
-    public enum AuthorizationMethod
+    internal enum AuthorizationMethod
     {
         None,
         Basic,

--- a/SynoAI/Notifiers/Webhook/Webhook.cs
+++ b/SynoAI/Notifiers/Webhook/Webhook.cs
@@ -1,14 +1,7 @@
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SynoAI.Models;
-using SynoAI.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace SynoAI.Notifiers.Webhook
 {

--- a/SynoAI/Notifiers/Webhook/Webhook.cs
+++ b/SynoAI/Notifiers/Webhook/Webhook.cs
@@ -8,7 +8,7 @@ namespace SynoAI.Notifiers.Webhook
     /// <summary>
     /// Calls a third party API.
     /// </summary>
-    public class Webhook : NotifierBase
+    internal class Webhook : NotifierBase
     {
         /// <summary>
         /// The URL to send the request to.

--- a/SynoAI/Notifiers/Webhook/WebhookFactory.cs
+++ b/SynoAI/Notifiers/Webhook/WebhookFactory.cs
@@ -1,6 +1,6 @@
 namespace SynoAI.Notifiers.Webhook
 {
-    public class WebhookFactory : NotifierFactory
+    internal class WebhookFactory : NotifierFactory
     {
         public override INotifier Create(ILogger logger, IConfigurationSection section)
         {

--- a/SynoAI/Notifiers/Webhook/WebhookFactory.cs
+++ b/SynoAI/Notifiers/Webhook/WebhookFactory.cs
@@ -1,6 +1,3 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-
 namespace SynoAI.Notifiers.Webhook
 {
     public class WebhookFactory : NotifierFactory

--- a/SynoAI/Program.cs
+++ b/SynoAI/Program.cs
@@ -1,7 +1,3 @@
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
-
-
 namespace SynoAI
 {
     public class Program

--- a/SynoAI/Services/AIService.cs
+++ b/SynoAI/Services/AIService.cs
@@ -4,7 +4,7 @@ using SynoAI.Models;
 
 namespace SynoAI.Services
 {
-    public class AIService : IAIService
+    internal class AIService : IAIService
     {
         private readonly ILogger<AIService> _logger;
 
@@ -19,7 +19,7 @@ namespace SynoAI.Services
             return await ai.Process(_logger, camera, image);
         }
 
-        private AI GetAI()
+        private static AI GetAI()
         {
             switch (Config.AI)
             {

--- a/SynoAI/Services/AIService.cs
+++ b/SynoAI/Services/AIService.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
-using SynoAI.AIs;
+﻿using SynoAI.AIs;
 using SynoAI.AIs.DeepStack;
 using SynoAI.Models;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace SynoAI.Services
 {

--- a/SynoAI/Services/IAIService.cs
+++ b/SynoAI/Services/IAIService.cs
@@ -1,8 +1,4 @@
 ﻿using SynoAI.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SynoAI.Services
 {

--- a/SynoAI/Services/ISynologyService.cs
+++ b/SynoAI/Services/ISynologyService.cs
@@ -1,7 +1,5 @@
 ﻿using SynoAI.Models;
-using System.Collections.Generic;
 using System.Net;
-using System.Threading.Tasks;
 
 namespace SynoAI.Services
 {

--- a/SynoAI/Services/SnapshotManager.cs
+++ b/SynoAI/Services/SnapshotManager.cs
@@ -5,8 +5,7 @@ using SynoAI.Extensions;
 
 namespace SynoAI.Services
 {
-
-    public class SnapshotManager
+    internal class SnapshotManager
     {
         /// <summary>
         /// Dresses the source image by adding the boundary boxes and saves the file locally.

--- a/SynoAI/Services/SnapshotManager.cs
+++ b/SynoAI/Services/SnapshotManager.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using SynoAI.Models;
 using SynoAI.Extensions;
@@ -13,14 +8,14 @@ namespace SynoAI.Services
 
     public class SnapshotManager
     {
- 
         /// <summary>
         /// Dresses the source image by adding the boundary boxes and saves the file locally.
         /// </summary>
         /// <param name="camera">The camera the image came from.</param>
         /// <param name="snapshot">The image data.</param>
         /// <param name="predictions">The list of predictions with the right size (but may or may not be the types configured as interest for this camera).</param>
-         /// <param name="validPredictions">The list of predictions with the right size and matching the type of objects of interest for this camera.</param>
+        /// <param name="validPredictions">The list of predictions with the right size and matching the type of objects of interest for this camera.</param>
+        /// <param name="logger"></param>
         public static ProcessedImage DressImage(Camera camera, byte[] snapshot, IEnumerable<AIPrediction> predictions, IEnumerable<AIPrediction> validPredictions, ILogger logger) 
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -154,6 +149,7 @@ namespace SynoAI.Services
         /// <summary>
         /// Saves the original unprocessed image from the provided byte array to the camera's capture directory.
         /// </summary>
+        /// <param name="logger"></param>
         /// <param name="camera">The camera to save the image for.</param>
         /// <param name="snapshot">The image to save.</param>
         public static string SaveOriginalImage(ILogger logger, Camera camera, byte[] snapshot)
@@ -166,8 +162,10 @@ namespace SynoAI.Services
         /// <summary>
         /// Saves the image to the camera's capture directory.
         /// </summary>
+        /// <param name="logger"></param>
         /// <param name="camera">The camera to save the image for.</param>
         /// <param name="image">The image to save.</param>
+        /// <param name="suffix"></param>
         private static string SaveImage(ILogger logger, Camera camera, SKBitmap image, string suffix = null)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -228,9 +226,9 @@ namespace SynoAI.Services
 
 
         /// <summary>
-        /// Parses the provided colour name into an SKColor.
+        /// Parses the provided hex name into an SKColor.
         /// </summary>
-        /// <param name="colour">The string to parse.</param>
+        /// <param name="hex">The string to parse.</param>
         private static SKColor GetColour(string hex)
         {
             if (!SKColor.TryParse(hex, out SKColor colour))

--- a/SynoAI/Services/SynologyService.cs
+++ b/SynoAI/Services/SynologyService.cs
@@ -5,7 +5,7 @@ using System.Web;
 
 namespace SynoAI.Services
 {
-    public class SynologyService : ISynologyService
+    internal class SynologyService : ISynologyService
     {
         /// <summary>
         /// The current cookie with valid authentication.
@@ -251,7 +251,7 @@ namespace SynoAI.Services
         /// <typeparam name="T">The type of the return 'data'.</typeparam>
         /// <param name="message">The message to parse.</param>
         /// <returns>A Synology response object.</returns>
-        private async Task<SynologyResponse<T>> GetResponse<T>(HttpResponseMessage message)
+        private static async Task<SynologyResponse<T>> GetResponse<T>(HttpResponseMessage message)
         {
             string content = await message.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<SynologyResponse<T>>(content);
@@ -262,7 +262,7 @@ namespace SynoAI.Services
         /// </summary>
         /// <param name="message">The message to parse.</param>
         /// <returns>A Synology response object.</returns>
-        private async Task<SynologyResponse> GetErrorResponse(HttpResponseMessage message)
+        private static async Task<SynologyResponse> GetErrorResponse(HttpResponseMessage message)
         {
             string content = await message.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<SynologyResponse>(content);
@@ -346,7 +346,7 @@ namespace SynoAI.Services
         /// <param name="baseAddress">The base URI.</param>
         /// <param name="cookieContainer">The container for the cookies.</param>
         /// <returns>An HttpClient.</returns>
-        private HttpClient GetHttpClient(string baseAddress, CookieContainer cookieContainer = null)
+        private static HttpClient GetHttpClient(string baseAddress, CookieContainer cookieContainer = null)
         {           
             Uri uri = new Uri(baseAddress);
             return GetHttpClient(uri, cookieContainer);
@@ -358,7 +358,7 @@ namespace SynoAI.Services
         /// <param name="baseUri">The base URI.</param>
         /// <param name="cookieContainer">The container for the cookies.</param>
         /// <returns>An HttpClient.</returns>
-        private HttpClient GetHttpClient(Uri baseUri, CookieContainer cookieContainer = null)
+        private static HttpClient GetHttpClient(Uri baseUri, CookieContainer cookieContainer = null)
         {           
             HttpClientHandler httpClientHandler = new HttpClientHandler();
             if (cookieContainer != null)

--- a/SynoAI/Services/SynologyService.cs
+++ b/SynoAI/Services/SynologyService.cs
@@ -1,13 +1,6 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using SynoAI.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
 using System.Web;
 
 namespace SynoAI.Services
@@ -40,8 +33,8 @@ namespace SynoAI.Services
         /// </summary>
         private static string _cameraPath { get; set; }
 
-        private IHostApplicationLifetime _applicationLifetime;
-        private ILogger<SynologyService> _logger;
+        private readonly IHostApplicationLifetime _applicationLifetime;
+        private readonly ILogger<SynologyService> _logger;
 
         public SynologyService(IHostApplicationLifetime applicationLifetime, ILogger<SynologyService> logger)
         {

--- a/SynoAI/Startup.cs
+++ b/SynoAI/Startup.cs
@@ -1,15 +1,6 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SynoAI.Services;
-using System.Threading.Tasks;
 using SynoAI.Hubs;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SynoAI
 {

--- a/SynoAI/SynoAI.csproj
+++ b/SynoAI/SynoAI.csproj
@@ -1,25 +1,44 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <UserSecretsId>28d148b3-8b53-4408-a54f-bf5663c58802</UserSecretsId>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Features>strict</Features>
+		<Nullable>disable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<UserSecretsId>28d148b3-8b53-4408-a54f-bf5663c58802</UserSecretsId>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+		<AnalysisLevel>latest-recommended</AnalysisLevel>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\README.md" Link="README.md" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+		<WarningsNotAsErrors>CS1591;CA1416</WarningsNotAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.15.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
-    <PackageReference Include="MQTTnet" Version="4.1.0.247" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.155" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.155" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Telegram.Bot" Version="17.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+		<WarningsNotAsErrors>CS1591;CA1416</WarningsNotAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\README.md" Link="README.md" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MailKit" Version="3.4.3" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+		<PackageReference Include="MQTTnet" Version="4.1.4.563" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="SkiaSharp" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+		<PackageReference Include="Telegram.Bot" Version="18.0.0" />
+		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/SynoAI/SynoAI.csproj
+++ b/SynoAI/SynoAI.csproj
@@ -10,19 +10,19 @@
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-		<AnalysisLevel>latest-recommended</AnalysisLevel>
+		<AnalysisLevel>6.0-minimum</AnalysisLevel>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-		<WarningsNotAsErrors>CS1591;CA1416</WarningsNotAsErrors>
+		<WarningsNotAsErrors>CS1591;CA1416;CA2254</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-		<WarningsNotAsErrors>CS1591;CA1416</WarningsNotAsErrors>
+		<WarningsNotAsErrors>CS1591;CA1416;CA2254</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SynoAI/Views/Home/Hour.cshtml
+++ b/SynoAI/Views/Home/Hour.cshtml
@@ -1,5 +1,4 @@
 @using SynoAI.Models
-@using System
 @{ 
     GraphDraw graphDraw = new GraphDraw();
     graphDraw.GraphWidth = 648;

--- a/SynoAI/Views/Home/Index.cshtml
+++ b/SynoAI/Views/Home/Index.cshtml
@@ -1,5 +1,4 @@
 @using SynoAI.Models
-@using System
 @{ 
     GraphDraw graphDraw = new GraphDraw();
     graphDraw.GraphWidth = 648;

--- a/SynoAI/Views/Home/Minute.cshtml
+++ b/SynoAI/Views/Home/Minute.cshtml
@@ -1,5 +1,3 @@
-@using SynoAI.Models
-@using System
 @{
     DateTime date = (DateTime)ViewData["date"];
     string camera = ViewData["camera"].ToString();

--- a/SynoAI/Views/Home/Realtime.cshtml
+++ b/SynoAI/Views/Home/Realtime.cshtml
@@ -1,5 +1,3 @@
-@using SynoAI.Models
-@using System
 @{
     string camera = ViewData["camera"].ToString();
 }

--- a/SynoAI/packages.lock.json
+++ b/SynoAI/packages.lock.json
@@ -1,0 +1,171 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net7.0": {
+      "MailKit": {
+        "type": "Direct",
+        "requested": "[3.4.3, )",
+        "resolved": "3.4.3",
+        "contentHash": "Iewef8mcE1B1LrVudxQjQ0LcriPPeTbxmWMoHQzFS+P6TpEY2eVDbdKdB0Qnbmqr/5w7WfK2mNWuoSX9pI470g==",
+        "dependencies": {
+          "MimeKit": "3.4.3"
+        }
+      },
+      "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
+        "type": "Direct",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "gfDtAL1WhkjbRdbZlt/ZeQYCbgRpNCZCGj+yeqHObsNFRDHjq8qZJOX9AyTxJpSRYMi9SJk7JDyAbbVYRgEhAA=="
+      },
+      "MQTTnet": {
+        "type": "Direct",
+        "requested": "[4.1.4.563, )",
+        "resolved": "4.1.4.563",
+        "contentHash": "gO9segUcKyQJcjV7w7OOdoAIkec7cUN65vEhYutbdWcj4rbtz/oL/RDvQVVbameXc6ChkjKx7/HbO+R8ejAUZQ=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.2, )",
+        "resolved": "13.0.2",
+        "contentHash": "R2pZ3B0UjeyHShm9vG+Tu0EBb2lC8b0dFzV9gVn50ofHXh9Smjk6kTn7A/FdAsC8B5cKib1OnGYOXxRBz5XQDg=="
+      },
+      "SkiaSharp": {
+        "type": "Direct",
+        "requested": "[2.88.3, )",
+        "resolved": "2.88.3",
+        "contentHash": "GG8X3EdfwyBfwjl639UIiOVOKEdeoqDgYrz0P1MUCnefXt9cofN+AK8YB/v1+5cLMr03ieWCQdDmPqnFIzSxZw==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "2.88.3",
+          "SkiaSharp.NativeAssets.macOS": "2.88.3"
+        }
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Direct",
+        "requested": "[2.88.3, )",
+        "resolved": "2.88.3",
+        "contentHash": "wz29evZVWRqN7WHfenFwQIgqtr8f5vHCutcl1XuhWrHTRZeaIBk7ngjhyHpjUMcQxtIEAdq34ZRvMQshsBYjqg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.3"
+        }
+      },
+      "Swashbuckle.AspNetCore": {
+        "type": "Direct",
+        "requested": "[6.4.0, )",
+        "resolved": "6.4.0",
+        "contentHash": "eUBr4TW0up6oKDA5Xwkul289uqSMgY0xGN4pnbOIBqCcN9VKGGaPvHX3vWaG/hvocfGDP+MGzMA0bBBKz2fkmQ==",
+        "dependencies": {
+          "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+          "Swashbuckle.AspNetCore.Swagger": "6.4.0",
+          "Swashbuckle.AspNetCore.SwaggerGen": "6.4.0",
+          "Swashbuckle.AspNetCore.SwaggerUI": "6.4.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "KIX+oBU38pxkKPxvLcLfIkOV5Ien8ReN78wro7OF5/erwcmortzeFx+iBswlh2Vz6gVne0khocQudGwaO1Ey6A==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "7.0.0"
+        }
+      },
+      "Telegram.Bot": {
+        "type": "Direct",
+        "requested": "[18.0.0, )",
+        "resolved": "18.0.0",
+        "contentHash": "BD0UchUXINymCGS+1O1tv2enCRyv+VbSJQAgfnueTZs3j7K4XXyJyW0CgyJleTrqB1oq1hS1ux6gBpi3Ajp+ZQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.2"
+        }
+      },
+      "Microsoft.Extensions.ApiDescription.Server": {
+        "type": "Transitive",
+        "resolved": "6.0.5",
+        "contentHash": "Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "Nug3rO+7Kl5/SBAadzSMAVgqDlfGjJZ0GenQrLywJ84XGKO0uRqkunz5Wyl0SDwcR71bAATXvSdbdzPrYRYKGw=="
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
+      },
+      "MimeKit": {
+        "type": "Transitive",
+        "resolved": "3.4.3",
+        "contentHash": "7TSAcziEwk0bGWODpFTQASghXfYNBBa5VdM8KO4s5SBp5LYgIVXcQsdLBpPQ2XhZW74wfaX8RBUMs1GTMlLJcA==",
+        "dependencies": {
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Security.Cryptography.Pkcs": "6.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0"
+        }
+      },
+      "Portable.BouncyCastle": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw=="
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "CEbWAXMGFkPV3S1snBKK7jEG3+xud/9kmSAhu0BEUKKtlMdxx+Qal0U9bntQREM9QpqP5xLWZooodi8IlV8MEg=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "2.88.3",
+        "contentHash": "MU4ASL8VAbTv5vSw1PoiWjjjpjtGhWtFYuJnrN4sNHFCePb2ohQij9JhSdqLLxk7RpRtWPdV93fbA53Pt+J0yw=="
+      },
+      "Swashbuckle.AspNetCore.Swagger": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "nl4SBgGM+cmthUcpwO/w1lUjevdDHAqRvfUoe4Xp/Uvuzt9mzGUwyFCqa3ODBAcZYBiFoKvrYwz0rabslJvSmQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.2.3"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "lXhcUBVqKrPFAQF7e/ZeDfb5PMgE8n5t6L5B6/BQSpiwxgHzmBcx8Msu42zLYFTvR5PIqE9Q9lZvSQAcwCxJjw==",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.4.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "1Hh3atb3pi8c+v7n4/3N80Jj8RvLOXgWxzix6w3OZhB7zBGRwsy7FWr4e3hwgPweSBpwfElqj4V4nkjYabH9nQ=="
+      },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T6fD00dQ3NTbPDy31m4eQUwKW84s03z0N2C8HpOklyeaDgaJPa/TexP4/SkORMSOwc7WhKifnA6Ya33AkzmafA=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "elM3x+xSRhzQysiqo85SbidJJ2YbZlnvmh+53TuSZHsD7dNuuEWser+9EFtY+rYupBwkq2avc6ZCO3/6qACgmg==",
+        "dependencies": {
+          "System.Formats.Asn1": "6.0.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I took the liberty to update SynoAI from .Net 5 to .Net 7 and also applied some fixes suggested by the dotnet compiler after enabling code analysis.

- Update csproj, docker and github actions to use dotnet 7
- Updated all referenced NuGet packages to their latest version
- Enabled TreatWarningsAsErrors during the build
- Enabled code analysis during the build by adding AnalysisLevel 6.0-recommended to the csproj file and fixed most of the warnings/errors they produced
- Excluded some errors from the build (some of which need to be fixed, like the one about logging)
- Made a lot of classes internal, this way the XML docs are not required for them
- Enabled the usage of a package.lock.json file
- Enabled ImplicitUsings and removed a lot of using from the classes

I hope this helps in the performance and stability of SynoAI. .NET 7 should be faster and have a lower memory footprint than .NET 5. If you approve this and like my changes, I will invest some more time in code optimizations. First by getting rid of all the warnings and then see if there are other places where the code could be improved.

